### PR TITLE
feat: anonymous auth onboarding with try-before-signup flow

### DIFF
--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -12,6 +12,7 @@ import {
   ShirtIcon,
   ShoppingCartIcon,
   User,
+  UserPlus,
   UsersIcon,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -20,6 +21,7 @@ import { Link, useLocation, useNavigate } from 'react-router'
 import { Avatar, AvatarFallback, AvatarImage } from '~/components/ui/avatar'
 import { useAuth } from '~/contexts/auth/useAuth'
 import { firebaseAuth } from '~/firebase/config'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
 
 import {
@@ -54,6 +56,7 @@ interface BottomNavProps {
 
 export function BottomNav({ className }: BottomNavProps) {
   const { user, setUser } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const location = useLocation()
   const navigate = useNavigate()
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -143,46 +146,73 @@ export function BottomNav({ className }: BottomNavProps) {
               <DrawerTitle>
                 <div className="flex items-center gap-3">
                   <Avatar className="size-10 border">
-                    <AvatarImage
-                      src={user?.photoURL ?? ''}
-                      alt={`${user?.username.toLocaleLowerCase()} avatar`}
-                      gravatarEmail={user?.email}
-                    />
-                    <AvatarFallback>
-                      {user?.displayName?.charAt(0) ??
-                        (user ? <Loader2 className="size-4 animate-spin" /> : '?')}
-                    </AvatarFallback>
+                    {isAnonymous ? (
+                      <AvatarFallback>
+                        <User className="size-5" />
+                      </AvatarFallback>
+                    ) : (
+                      <>
+                        <AvatarImage
+                          src={user?.photoURL ?? ''}
+                          alt={`${user?.username.toLocaleLowerCase()} avatar`}
+                          gravatarEmail={user?.email}
+                        />
+                        <AvatarFallback>
+                          {user?.displayName?.charAt(0) ??
+                            (user ? <Loader2 className="size-4 animate-spin" /> : '?')}
+                        </AvatarFallback>
+                      </>
+                    )}
                   </Avatar>
                   <div className="grid text-left leading-tight">
-                    <span className="font-bold">{user?.displayName}</span>
-                    <span className="text-muted-foreground text-sm font-normal">
-                      @{user?.username.toLocaleLowerCase()}
+                    <span className="font-bold">
+                      {isAnonymous ? 'Guest' : user?.displayName}
                     </span>
-                    <span className="text-muted-foreground text-xs font-normal">
-                      Joined {format(user?.createdAt?.toDate() ?? new Date(), 'MMMM yyyy')}
-                    </span>
+                    {!isAnonymous && (
+                      <span className="text-muted-foreground text-sm font-normal">
+                        @{user?.username.toLocaleLowerCase()}
+                      </span>
+                    )}
+                    {!isAnonymous && (
+                      <span className="text-muted-foreground text-xs font-normal">
+                        Joined {format(user?.createdAt?.toDate() ?? new Date(), 'MMMM yyyy')}
+                      </span>
+                    )}
                   </div>
                 </div>
               </DrawerTitle>
             </DrawerHeader>
             <Separator />
             <div className="flex flex-col p-2">
-              {moreItems.map((item) => (
-                <DrawerClose key={item.href} asChild>
+              {isAnonymous && (
+                <DrawerClose asChild>
                   <Link
-                    to={item.href}
-                    className={cn(
-                      'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors',
-                      isActive(item.href)
-                        ? 'bg-sidebar-accent text-sidebar-accent-foreground'
-                        : 'text-foreground hover:bg-sidebar-accent'
-                    )}
+                    to="/signup"
+                    className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-bold transition-colors text-foreground hover:bg-sidebar-accent"
                   >
-                    <item.icon className="size-5" />
-                    {item.label}
+                    <UserPlus className="size-5" />
+                    Create Account
                   </Link>
                 </DrawerClose>
-              ))}
+              )}
+              {moreItems
+                .filter((item) => !isAnonymous || item.label !== 'Profile')
+                .map((item) => (
+                  <DrawerClose key={item.href} asChild>
+                    <Link
+                      to={item.href}
+                      className={cn(
+                        'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors',
+                        isActive(item.href)
+                          ? 'bg-sidebar-accent text-sidebar-accent-foreground'
+                          : 'text-foreground hover:bg-sidebar-accent'
+                      )}
+                    >
+                      <item.icon className="size-5" />
+                      {item.label}
+                    </Link>
+                  </DrawerClose>
+                ))}
             </div>
             <Separator />
             <div className="p-2">

--- a/app/components/Chat/ChatSheet.tsx
+++ b/app/components/Chat/ChatSheet.tsx
@@ -1,7 +1,8 @@
 import { formatDistanceToNow, isAfter, subSeconds } from 'date-fns'
 import { orderBy } from 'firebase/firestore'
-import { Dot, MessageCircleIcon, Reply, XIcon } from 'lucide-react'
+import { Dot, MessageCircleIcon, Reply, UserPlus, XIcon } from 'lucide-react'
 import { useCallback, useMemo, useState } from 'react'
+import { Link } from 'react-router'
 
 import { Button } from '~/components/ui/button'
 import {
@@ -15,6 +16,7 @@ import {
 } from '~/components/ui/sheet'
 import useAuth from '~/contexts/auth/useAuth'
 import { createChatMessage } from '~/lib/chat'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
 import {
   useCreateChatMessage,
@@ -45,6 +47,7 @@ const systemUser: User = {
 
 function ChatSheet({ trip, users, compact }: ChatSheetProps) {
   const { user } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const [userMap] = useState<Map<string, User>>(
     new Map([...(users || []).map((u): [string, User] => [u.id, u]), [systemUser.id, systemUser]])
   )
@@ -192,6 +195,21 @@ function ChatSheet({ trip, users, compact }: ChatSheetProps) {
               : `Planning and discussion for ${trip.name}`}
           </SheetDescription>
         </SheetHeader>
+        {isAnonymous ? (
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+            <UserPlus className="text-muted-foreground size-8" />
+            <p className="text-muted-foreground">
+              Create an account to chat with trip members
+            </p>
+            <Button variant="accent" asChild>
+              <Link to="/signup">
+                <UserPlus className="size-4" />
+                Create Account
+              </Link>
+            </Button>
+          </div>
+        ) : (
+          <>
         <ChatContainer
           messages={messages ?? []}
           currentUserId={user?.uid ?? ''}
@@ -246,6 +264,8 @@ function ChatSheet({ trip, users, compact }: ChatSheetProps) {
             />
           </div>
         </SheetFooter>
+          </>
+        )}
       </SheetContent>
     </Sheet>
   )

--- a/app/components/LoginForm.tsx
+++ b/app/components/LoginForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Loader2, Mail, WandSparkles } from 'lucide-react'
+import { AlertTriangle, Loader2, Mail, WandSparkles } from 'lucide-react'
 import { AnimatePresence } from 'motion/react'
 import { useState } from 'react'
 import { type MouseEventHandler } from 'react'
@@ -9,6 +9,7 @@ import { animated } from 'react-spring'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
+import { firebaseAuth } from '~/firebase/config'
 import useBoop from '~/lib/useBoop'
 
 import AnimatedContainer from './AnimatedContainer'
@@ -83,8 +84,22 @@ export function LoginForm() {
     }
   }
 
+  const hasAnonymousSession = firebaseAuth.currentUser?.isAnonymous === true
+
   return (
     <div className="flex flex-col items-center">
+      {hasAnonymousSession && (
+        <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-800 dark:bg-amber-950/50">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <p className="text-amber-800 dark:text-amber-200">
+            You have trips from this session. Create a{' '}
+            <a href="/signup" className="font-bold underline">
+              new account
+            </a>{' '}
+            to keep them, or sign in to your existing account (these trips won't transfer).
+          </p>
+        </div>
+      )}
       <AnimatePresence mode="wait">
         {sent ? (
           <AnimatedContainer

--- a/app/components/PageContent.tsx
+++ b/app/components/PageContent.tsx
@@ -8,7 +8,7 @@ type PageContentProps = {
 const PageContent = ({ children, noPadding }: PageContentProps) => {
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <div className={cn('h-full min-h-0 w-full overflow-y-auto p-4 md:p-8', noPadding && 'p-0')}>
+      <div className={cn('h-full min-h-0 w-full overflow-y-auto p-4 md:p-8', noPadding && 'p-0!')}>
         {children}
       </div>
     </div>

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ShirtIcon,
   ShoppingCartIcon,
   User,
+  UserPlus,
   UsersIcon,
 } from 'lucide-react'
 import { useState } from 'react'
@@ -24,6 +25,7 @@ import { useAuth } from '~/contexts/auth/useAuth'
 import { useSidebarState } from '~/contexts/globalState'
 import { firebaseAuth } from '~/firebase/config'
 import useBoop from '~/lib/useBoop'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
 
 import { Logo } from './Logo'
@@ -43,6 +45,7 @@ interface SidebarProps {
 
 export function Sidebar({ className }: SidebarProps) {
   const { user, setUser } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const { isSidebarCollapsed, setIsSidebarCollapsed } = useSidebarState()
   const [nextStyle, triggerNext] = useBoop({ x: 2 }) as [any, () => void]
   const [animatingItem, setAnimatingItem] = useState<string | null>(null)
@@ -167,23 +170,35 @@ export function Sidebar({ className }: SidebarProps) {
             <DropdownMenuTrigger asChild>
               <div className="text-sidebar-foreground hover:text-sidebar-accent-foreground data-[state=open]:bg-sidebar-accent hover:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground flex items-center justify-center gap-2 rounded-lg px-3 py-2 transition-colors">
                 <Avatar className="h-8 w-8 border">
-                  <AvatarImage
-                    src={user?.photoURL ?? ''}
-                    alt={`${user?.username.toLocaleLowerCase()} avatar`}
-                    gravatarEmail={user?.email}
-                  />
-                  <AvatarFallback>
-                    {user?.displayName?.charAt(0) ??
-                      (user ? <Loader2 className="h-4 w-4 animate-spin" /> : '?')}
-                  </AvatarFallback>
+                  {isAnonymous ? (
+                    <AvatarFallback>
+                      <User className="size-4" />
+                    </AvatarFallback>
+                  ) : (
+                    <>
+                      <AvatarImage
+                        src={user?.photoURL ?? ''}
+                        alt={`${user?.username.toLocaleLowerCase()} avatar`}
+                        gravatarEmail={user?.email}
+                      />
+                      <AvatarFallback>
+                        {user?.displayName?.charAt(0) ??
+                          (user ? <Loader2 className="h-4 w-4 animate-spin" /> : '?')}
+                      </AvatarFallback>
+                    </>
+                  )}
                 </Avatar>
                 {!isSidebarCollapsed && (
                   <>
                     <div className="grid flex-1 text-left text-sm leading-tight">
-                      <span className="truncate font-medium">{user?.displayName}</span>
-                      <span className="text-muted-foreground truncate text-xs">
-                        @{user?.username.toLocaleLowerCase()}
+                      <span className="truncate font-medium">
+                        {isAnonymous ? 'Guest' : user?.displayName}
                       </span>
+                      {!isAnonymous && (
+                        <span className="text-muted-foreground truncate text-xs">
+                          @{user?.username.toLocaleLowerCase()}
+                        </span>
+                      )}
                     </div>
                     <EllipsisVertical className="ml-auto size-4" />
                   </>
@@ -199,36 +214,71 @@ export function Sidebar({ className }: SidebarProps) {
               <DropdownMenuLabel className="p-0 font-normal">
                 <div className="flex items-start gap-2 px-1 py-1.5 text-left text-sm">
                   <Avatar className="size-12 border">
-                    <AvatarImage
-                      src={user?.photoURL ?? ''}
-                      alt={`${user?.username.toLocaleLowerCase()} avatar`}
-                      gravatarEmail={user?.email}
-                    />
-                    <AvatarFallback>
-                      {user?.displayName?.charAt(0) ??
-                        (user ? <Loader2 className="h-4 w-4 animate-spin" /> : '?')}
-                    </AvatarFallback>
+                    {isAnonymous ? (
+                      <AvatarFallback>
+                        <User className="size-6" />
+                      </AvatarFallback>
+                    ) : (
+                      <>
+                        <AvatarImage
+                          src={user?.photoURL ?? ''}
+                          alt={`${user?.username.toLocaleLowerCase()} avatar`}
+                          gravatarEmail={user?.email}
+                        />
+                        <AvatarFallback>
+                          {user?.displayName?.charAt(0) ??
+                            (user ? <Loader2 className="h-4 w-4 animate-spin" /> : '?')}
+                        </AvatarFallback>
+                      </>
+                    )}
                   </Avatar>
                   <div className="grid flex-1 text-left leading-tight">
-                    <span className="font-bold">{user?.displayName}</span>
-                    <span className="">@{user?.username.toLocaleLowerCase()}</span>
-                    <span className="text-muted-foreground text-xs">
-                      Joined {format(user?.createdAt?.toDate() ?? new Date(), 'MMMM yyyy')}
+                    <span className="font-bold">
+                      {isAnonymous ? 'Guest' : user?.displayName}
                     </span>
+                    {!isAnonymous && (
+                      <span className="">@{user?.username.toLocaleLowerCase()}</span>
+                    )}
+                    {!isAnonymous && (
+                      <span className="text-muted-foreground text-xs">
+                        Joined {format(user?.createdAt?.toDate() ?? new Date(), 'MMMM yyyy')}
+                      </span>
+                    )}
                   </div>
                 </div>
               </DropdownMenuLabel>
               <DropdownMenuSeparator />
-              <DropdownMenuGroup>
-                {bottomItems.map((item) => (
-                  <DropdownMenuItem key={item.label} asChild>
-                    <Link to={item.href}>
-                      <item.icon />
-                      {item.label}
+              {isAnonymous ? (
+                <DropdownMenuGroup>
+                  <DropdownMenuItem asChild>
+                    <Link to="/signup" className="font-bold">
+                      <UserPlus className="size-4" />
+                      Create Account
                     </Link>
                   </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
+                  {bottomItems
+                    .filter((item) => item.label !== 'Profile')
+                    .map((item) => (
+                      <DropdownMenuItem key={item.label} asChild>
+                        <Link to={item.href}>
+                          <item.icon />
+                          {item.label}
+                        </Link>
+                      </DropdownMenuItem>
+                    ))}
+                </DropdownMenuGroup>
+              ) : (
+                <DropdownMenuGroup>
+                  {bottomItems.map((item) => (
+                    <DropdownMenuItem key={item.label} asChild>
+                      <Link to={item.href}>
+                        <item.icon />
+                        {item.label}
+                      </Link>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuGroup>
+              )}
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={handleLogout} variant="destructive">
                 <LogOut />

--- a/app/components/SignupForm.tsx
+++ b/app/components/SignupForm.tsx
@@ -1,10 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
   createUserWithEmailAndPassword,
+  EmailAuthProvider,
+  linkWithCredential,
   sendSignInLinkToEmail,
   type UserCredential,
 } from 'firebase/auth'
-import { Timestamp } from 'firebase/firestore'
+import { doc, Timestamp, updateDoc } from 'firebase/firestore'
 import { BadgeCheck, ChevronLeft, ChevronRight, Loader2, Mail, UserPlus } from 'lucide-react'
 import { AnimatePresence } from 'motion/react'
 import { useCallback, useEffect, useState } from 'react'
@@ -14,7 +16,7 @@ import { animated } from 'react-spring'
 import { toast } from 'sonner'
 import { z } from 'zod'
 
-import { firebaseAuth } from '~/firebase/config'
+import { firebaseAuth, firestoreDb } from '~/firebase/config'
 import { generatePassword } from '~/lib/generatePassword'
 import useBoop from '~/lib/useBoop'
 import { cn } from '~/lib/utils'
@@ -210,23 +212,45 @@ export function SignupForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setLoading(true)
     const password = await generatePassword(16)
+    const currentUser = firebaseAuth.currentUser
+    const isUpgrading = currentUser?.isAnonymous === true
 
     window.localStorage.setItem('emailForSignIn', values.email)
 
-    createUserWithEmailAndPassword(firebaseAuth, values.email, password)
-      .then((result) => {
-        if (result.user && result.user.email) {
-          createUserFromAuthResult(result, values.username, values.displayName)
+    try {
+      if (isUpgrading && currentUser) {
+        const credential = EmailAuthProvider.credential(values.email, password)
+        const result = await linkWithCredential(currentUser, credential)
+
+        const userDocRef = doc(firestoreDb, 'users', result.user.uid)
+        await updateDoc(userDocRef, {
+          isAnonymous: false,
+          email: values.email,
+          displayName: values.displayName,
+          username: values.username,
+          lastUpdated: Timestamp.now(),
+        })
+
+        if (result.user.email) {
+          const actionCodeSettings = {
+            url: `${window.location.origin}/signin`,
+            handleCodeInApp: true,
+          }
+          sendSignInLinkToEmail(firebaseAuth, result.user.email, actionCodeSettings)
         }
-      })
-      .catch((error) => {
-        toast.error('Failed to create account. Please try again.')
-        console.error('Signup error:', error)
-      })
-      .finally(() => {
-        setLoading(false)
-        setSubmitted(true)
-      })
+      } else {
+        const result = await createUserWithEmailAndPassword(firebaseAuth, values.email, password)
+        if (result.user && result.user.email) {
+          await createUserFromAuthResult(result, values.username, values.displayName)
+        }
+      }
+    } catch (error) {
+      toast.error('Failed to create account. Please try again.')
+      console.error('Signup error:', error)
+    } finally {
+      setLoading(false)
+      setSubmitted(true)
+    }
   }
 
   const isIOS = /iphone|ipad/.test(navigator.userAgent.toLowerCase())

--- a/app/components/Trip/AddTripPartyMember.tsx
+++ b/app/components/Trip/AddTripPartyMember.tsx
@@ -21,6 +21,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover
 import { useAuth } from '~/contexts/auth/useAuth'
 import { createSystemMessage } from '~/lib/chat'
 import { formattedDateRange } from '~/lib/date'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { algoliaSearch } from '~/services/algoliaSearch'
 import { useCreateChatMessage, useUpdateTrip } from '~/services/trips'
 import type { Trip } from '~/types/Trip'
@@ -41,6 +42,7 @@ export function AddTripPartyMember({
   const { mutateAsync: updateTrip } = useUpdateTrip(trip.tripId)
   const { mutateAsync: sendMessage } = useCreateChatMessage()
   const { user } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const { id } = useParams()
   const fetcher = useFetcher()
 
@@ -235,6 +237,10 @@ export function AddTripPartyMember({
       console.error('Error adding member to trip:', error)
       setIsAddingMember(null)
     }
+  }
+
+  if (isAnonymous) {
+    return null
   }
 
   return (

--- a/app/components/UpgradeAccountGate.tsx
+++ b/app/components/UpgradeAccountGate.tsx
@@ -1,0 +1,69 @@
+import { UserPlus } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Link } from 'react-router'
+
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
+
+import { Button } from './ui/button'
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from './ui/empty'
+
+interface UpgradeAccountGateProps {
+  message: string
+  children: ReactNode
+}
+
+export function UpgradeAccountGate({ message, children }: UpgradeAccountGateProps) {
+  const isAnonymous = useIsAnonymous()
+
+  if (!isAnonymous) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <UserPlus />
+          </EmptyMedia>
+          <EmptyTitle>{message}</EmptyTitle>
+          <EmptyDescription>
+            Keep your trips, invite friends, and access your data from any device.
+          </EmptyDescription>
+          <EmptyContent>
+            <Button variant="accent" size="lg" asChild>
+              <Link to="/signup">
+                <UserPlus className="size-4" />
+                Create Account
+              </Link>
+            </Button>
+          </EmptyContent>
+        </EmptyHeader>
+      </Empty>
+      {/* <div className="flex flex-col items-center justify-center gap-6 py-16 text-center">
+        <div className="bg-muted rounded-full p-4">
+          <UserPlus className="text-muted-foreground size-8" />
+        </div>
+        <div className="max-w-sm space-y-2">
+          <p className="text-lg font-medium">{message}</p>
+          <p className="text-muted-foreground text-sm">
+            Keep your trips, invite friends, and access your data from any device.
+          </p>
+        </div>
+        <Button variant="accent" size="lg" asChild>
+          <Link to="/signup">
+            <UserPlus className="size-4" />
+            Create Account
+          </Link>
+        </Button>
+      </div> */}
+    </>
+  )
+}

--- a/app/components/ui/empty.tsx
+++ b/app/components/ui/empty.tsx
@@ -19,19 +19,19 @@ function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="empty-header"
-      className={cn('flex max-w-sm flex-col items-center gap-2 text-center', className)}
+      className={cn('flex max-w-md flex-col items-center gap-4 text-center', className)}
       {...props}
     />
   )
 }
 
 const emptyMediaVariants = cva(
-  'flex shrink-0 items-center justify-center mb-2 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  'flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
   {
     variants: {
       variant: {
         default: 'bg-transparent',
-        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+        icon: 'flex size-8 shrink-0 items-center justify-center text-muted-foreground',
       },
     },
     defaultVariants: {
@@ -46,17 +46,19 @@ function EmptyMedia({
   ...props
 }: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
   return (
-    <div
-      data-slot="empty-icon"
-      data-variant={variant}
-      className={cn(emptyMediaVariants({ variant, className }))}
-      {...props}
-    />
+    <div className="bg-muted rounded-full p-4">
+      <div
+        data-slot="empty-icon"
+        data-variant={variant}
+        className={cn(emptyMediaVariants({ variant, className }))}
+        {...props}
+      />
+    </div>
   )
 }
 
 function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
-  return <div data-slot="empty-title" className={cn('text-lg', className)} {...props} />
+  return <div data-slot="empty-title" className={cn('text-lg font-bold', className)} {...props} />
 }
 
 function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
@@ -77,7 +79,7 @@ function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="empty-content"
       className={cn(
-        'flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance',
+        'flex w-full max-w-md min-w-0 flex-col items-center gap-4 text-sm text-balance',
         className
       )}
       {...props}

--- a/app/contexts/auth/authProvider.tsx
+++ b/app/contexts/auth/authProvider.tsx
@@ -70,15 +70,17 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
   useEffect(() => {
     if (currentUser) {
       setUser(currentUser)
-      identify(
-        currentUser.email,
-        currentUser.uid,
-        currentUser.displayName,
-        currentUser.createdAt?.toDate().toISOString() ?? '',
-        currentUser?.username
-      )
+      if (!firebaseUser?.isAnonymous) {
+        identify(
+          currentUser.email,
+          currentUser.uid,
+          currentUser.displayName,
+          currentUser.createdAt?.toDate().toISOString() ?? '',
+          currentUser?.username
+        )
+      }
     }
-  }, [currentUser])
+  }, [currentUser, firebaseUser?.isAnonymous])
 
   // Don't show loading spinner if we already have a user
   // This prevents the spinner from showing on route changes

--- a/app/lib/useIsAnonymous.ts
+++ b/app/lib/useIsAnonymous.ts
@@ -1,0 +1,6 @@
+import { useAuth } from '~/contexts/auth/useAuth'
+
+export function useIsAnonymous() {
+  const { user } = useAuth()
+  return user?.isAnonymous ?? false
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,7 +2,6 @@ import './app.css'
 
 // import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 // import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { useEffect } from 'react'
 import {
@@ -148,7 +147,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
             {children}
             {loaderData.showCookieBanner && <CookieBanner />}
           </TooltipProvider>
-          <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
+          {/* <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" /> */}
         </QueryClientProvider>
         <ScrollRestoration />
         <Scripts />

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -4,6 +4,7 @@ export default [
   index('routes/home.tsx'),
   route('signin', 'routes/signin.tsx'),
   route('signup', 'routes/signup.tsx'),
+  route('get-started', 'routes/get-started.tsx'),
   layout('components/AuthWrapper.tsx', [
     route('feedback', 'routes/feedback.tsx'),
     route('friends', 'routes/friends.tsx'),

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,5 +1,7 @@
 import PageContent from '~/components/PageContent'
 import PageHeader from '~/components/PageHeader'
+import { UpgradeAccountGate } from '~/components/UpgradeAccountGate'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 
 import type { Route } from './+types/home'
 
@@ -8,11 +10,19 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export default function Friends() {
+  const isAnonymous = useIsAnonymous()
+
   return (
     <>
       <PageHeader crumbs={[{ label: 'Friends', href: '/friends' }]} />
       <PageContent>
-        <p>Friends will go here</p>
+        {isAnonymous ? (
+          <UpgradeAccountGate message="Create an account to connect with friends">
+            <div />
+          </UpgradeAccountGate>
+        ) : (
+          <p>Friends will go here</p>
+        )}
       </PageContent>
     </>
   )

--- a/app/routes/gear-closet.tsx
+++ b/app/routes/gear-closet.tsx
@@ -10,7 +10,9 @@ import ManageTagsDialog from '~/components/GearCloset/ManageTagsDialog'
 import PageContent from '~/components/PageContent'
 import PageHeader from '~/components/PageHeader'
 import { Button } from '~/components/ui/button'
+import { UpgradeAccountGate } from '~/components/UpgradeAccountGate'
 import useAuth from '~/contexts/auth/useAuth'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import {
   useGearClosetAdditionsQuery,
   useGearClosetQuery,
@@ -44,6 +46,7 @@ function masterItemToClosetItem(item: GearItem, removals: string[]): GearClosetI
 
 export default function GearCloset() {
   const { user } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const userId = user?.uid ?? ''
 
   const {
@@ -93,7 +96,11 @@ export default function GearCloset() {
     <>
       <PageHeader crumbs={[{ label: 'Gear Closet', href: '/gear-closet' }]} />
       <PageContent>
-        {isLoading ? (
+        {isAnonymous ? (
+          <UpgradeAccountGate message="Create an account to build your personal gear closet">
+            <div />
+          </UpgradeAccountGate>
+        ) : isLoading ? (
           <FullPageSpinner what="gear closet" />
         ) : (
           <div className="mx-auto max-w-3xl space-y-4">

--- a/app/routes/get-started.tsx
+++ b/app/routes/get-started.tsx
@@ -1,0 +1,81 @@
+import { onAuthStateChanged, signInAnonymously } from 'firebase/auth'
+import { Timestamp } from 'firebase/firestore'
+import { Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+
+import { firebaseAuth } from '~/firebase/config'
+import { useCreateUser } from '~/services/users'
+
+import type { Route } from './+types/home'
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: 'Get Started | Packup' },
+    {
+      name: 'description',
+      content: 'Try Packup free — no account needed. Create a trip and start packing right away.',
+    },
+  ]
+}
+
+export default function GetStarted() {
+  const navigate = useNavigate()
+  const { mutateAsync: createUserAsync } = useCreateUser()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(firebaseAuth, async (user) => {
+      if (user && !user.isAnonymous) {
+        navigate('/trips', { replace: true })
+        return
+      }
+
+      if (user && user.isAnonymous) {
+        navigate('/trips/new', { replace: true })
+        return
+      }
+
+      try {
+        const result = await signInAnonymously(firebaseAuth)
+        const now = Timestamp.now()
+
+        await createUserAsync({
+          id: result.user.uid,
+          uid: result.user.uid,
+          email: '',
+          displayName: '',
+          username: '',
+          isAnonymous: true,
+          createdAt: now,
+          lastUpdated: now,
+        })
+
+        navigate('/trips/new', { replace: true })
+      } catch (err) {
+        console.error('Anonymous sign-in failed:', err)
+        setError('Something went wrong. Please try again.')
+      }
+    })
+
+    return () => unsubscribe()
+  }, [navigate, createUserAsync])
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <p className="text-destructive">{error}</p>
+        <a href="/" className="font-bold hover:underline">
+          Back to sign in
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+      <Loader2 className="size-8 animate-spin" />
+      <p className="text-muted-foreground">Setting up your experience...</p>
+    </div>
+  )
+}

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,10 +1,12 @@
 import { onAuthStateChanged } from 'firebase/auth'
+import { ArrowRight } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 
 import FullPageSpinner from '~/components/FullPageSpinner'
 import { LoginForm } from '~/components/LoginForm'
 import { Logo } from '~/components/Logo'
+import { Button } from '~/components/ui/button'
 import { Separator } from '~/components/ui/separator'
 import { firebaseAuth } from '~/firebase/config'
 import { trackPage } from '~/lib/analytics'
@@ -34,7 +36,6 @@ export default function Home() {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(firebaseAuth, (user) => {
       if (user) {
-        // Add a small delay to ensure the component has fully rendered
         setTimeout(() => {
           navigate('/trips', { replace: true })
         }, 100)
@@ -69,6 +70,15 @@ export default function Home() {
               </div>
             </>
           )}
+        </div>
+
+        <div className="w-full text-center">
+          <Button variant="ghost" size="lg" asChild className="w-full">
+            <Link to="/get-started">
+              Try it free — no account needed
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/routes/profile.tsx
+++ b/app/routes/profile.tsx
@@ -1,5 +1,9 @@
+import { UserPlus } from 'lucide-react'
+
 import PageContent from '~/components/PageContent'
 import PageHeader from '~/components/PageHeader'
+import { SignupForm } from '~/components/SignupForm'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 
 import type { Route } from './+types/home'
 
@@ -8,11 +12,30 @@ export function meta({}: Route.MetaArgs) {
 }
 
 export default function Profile() {
+  const isAnonymous = useIsAnonymous()
+
   return (
     <>
       <PageHeader crumbs={[{ label: 'Profile', href: '/profile' }]} />
       <PageContent>
-        <p>Profile will go here</p>
+        {isAnonymous ? (
+          <div className="mx-auto max-w-md space-y-6 py-8">
+            <div className="space-y-2 text-center">
+              <div className="bg-muted mx-auto w-fit rounded-full p-4">
+                <UserPlus className="text-muted-foreground size-8" />
+              </div>
+              <h2 className="text-2xl font-bold">Create your profile</h2>
+              <p className="text-muted-foreground">
+                Save your trips, invite friends, and access your data from any device.
+              </p>
+            </div>
+            <div className="rounded border bg-gray-100/50 p-8 dark:bg-gray-800">
+              <SignupForm />
+            </div>
+          </div>
+        ) : (
+          <p>Profile will go here</p>
+        )}
       </PageContent>
     </>
   )

--- a/app/routes/signup.tsx
+++ b/app/routes/signup.tsx
@@ -32,8 +32,7 @@ export default function Signup() {
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(firebaseAuth, (user) => {
-      if (user) {
-        // Add a small delay to ensure the component has fully rendered
+      if (user && !user.isAnonymous) {
         setTimeout(() => {
           navigate('/trips', { replace: true })
         }, 100)

--- a/app/routes/trips/$id.tsx
+++ b/app/routes/trips/$id.tsx
@@ -1,5 +1,7 @@
 import { limit, where } from 'firebase/firestore'
-import { useEffect, useMemo } from 'react'
+import { Info, UserPlus, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
 
 import ChatSheet from '~/components/Chat/ChatSheet'
 import FullPageSpinner from '~/components/FullPageSpinner'
@@ -8,6 +10,9 @@ import PageHeader from '~/components/PageHeader'
 import MobileTripDetailsDrawer from '~/components/Trip/MobileTripDetailsDrawer'
 import TripDetailsSidebar from '~/components/Trip/TripDetailsSidebar'
 import TripPackingList from '~/components/Trip/TripPackingList'
+import { Button } from '~/components/ui/button'
+import useAuth from '~/contexts/auth/useAuth'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { useTripByIdQuery, useTripMembersQuery } from '~/services/trips'
 
 import type { Route } from './+types/$id'
@@ -18,8 +23,20 @@ export function meta({}: Route.MetaArgs) {
 
 export default function TripDetails({ params }: Route.ComponentProps) {
   const { id } = params
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const isAnonymous = useIsAnonymous()
+  const [showBanner, setShowBanner] = useState(true)
 
   const { data: trip, isLoading: isLoadingTrip } = useTripByIdQuery({ tripId: id })
+
+  useEffect(() => {
+    if (!trip || isLoadingTrip || !user) return
+    const isMember = user.uid in (trip.tripMembers ?? {})
+    if (!isMember) {
+      navigate('/trips', { replace: true })
+    }
+  }, [trip, isLoadingTrip, user, navigate])
 
   const constraints = useMemo(
     () =>
@@ -67,6 +84,28 @@ export default function TripDetails({ params }: Route.ComponentProps) {
         ) : (
           <div className="relative flex h-full min-h-0 flex-col md:flex-row">
             <div className="flex-1 overflow-y-auto p-4 md:w-2/3 md:p-8">
+              {isAnonymous && showBanner && (
+                <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/50">
+                  <div className="flex items-center gap-2 text-sm text-blue-800 dark:text-blue-200">
+                    <Info className="size-4 shrink-0" />
+                    <span>Sign up to save this trip and access it from any device.</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Button variant="accent" size="sm" asChild>
+                      <Link to="/signup">
+                        <UserPlus className="size-3" />
+                        Sign up
+                      </Link>
+                    </Button>
+                    <button
+                      onClick={() => setShowBanner(false)}
+                      className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200"
+                    >
+                      <X className="size-4" />
+                    </button>
+                  </div>
+                </div>
+              )}
               <TripPackingList tripId={id} users={users} />
             </div>
             <div className="bg-sidebar border-sidebar-border hidden w-1/3 overflow-y-auto border-l md:block">

--- a/app/routes/trips/index.tsx
+++ b/app/routes/trips/index.tsx
@@ -1,6 +1,6 @@
 import { where } from 'firebase/firestore'
-import { PlusCircle } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
+import { Info, PlusCircle, UserPlus, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router'
 import { toast } from 'sonner'
 
@@ -11,8 +11,17 @@ import PageHeader from '~/components/PageHeader'
 import TripCard from '~/components/Trip/TripCard'
 import { Badge } from '~/components/ui/badge'
 import { Button } from '~/components/ui/button'
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '~/components/ui/empty'
 import { useAuth } from '~/contexts/auth/useAuth'
 import { isAfterToday, isBeforeToday } from '~/lib/date'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { useTripsQuery } from '~/services/trips'
 import type { Trip } from '~/types/Trip'
 import { TripMemberStatus } from '~/types/TripMember'
@@ -44,6 +53,8 @@ function groupTripsByYear(trips: TripWithStatus[]): { [year: string]: TripWithSt
 
 export default function Trips() {
   const { user } = useAuth()
+  const isAnonymous = useIsAnonymous()
+  const [showBanner, setShowBanner] = useState(true)
 
   const constraints = useMemo(
     () => [
@@ -104,6 +115,28 @@ export default function Trips() {
       <PageContent>
         <div className="">
           <div className="mx-auto w-full max-w-4xl">
+            {isAnonymous && showBanner && (
+              <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950/50">
+                <div className="flex items-center gap-2 text-sm text-blue-800 dark:text-blue-200">
+                  <Info className="size-4 shrink-0" />
+                  <span>Sign up to save your trips and access them from any device.</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link to="/signup">
+                      <UserPlus className="size-3" />
+                      Sign up
+                    </Link>
+                  </Button>
+                  <button
+                    onClick={() => setShowBanner(false)}
+                    className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200"
+                  >
+                    <X className="size-4" />
+                  </button>
+                </div>
+              </div>
+            )}
             {isLoading && <FullPageSpinner what="trips" />}
             {!isLoading && tripsWithStatus.length > 0 && (
               <div className="space-y-0 md:-ml-18">
@@ -143,21 +176,42 @@ export default function Trips() {
               </div>
             )}
             {!isLoading && tripsWithStatus.length === 0 && (
-              <div className="mx-auto flex max-w-md flex-col items-center space-y-8 text-center">
-                <Logo className="size-16" fill="var(--muted-foreground)" />
-                <h2 className="text-2xl font-bold">Welcome, adventurer!</h2>
-                <p>
-                  No trips found yet. Create your first trip and start packing for your next
-                  adventure.
-                </p>
-                <Button asChild variant="accent" className="group">
-                  <Link to="/trips/new">
-                    <PlusCircle className="h-5 w-5 shrink-0 transition-transform duration-300 group-hover:rotate-90" />
+              <Empty>
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <Logo fill="var(--muted-foreground)" />
+                  </EmptyMedia>
+                  <EmptyTitle>Welcome, adventurer!</EmptyTitle>
+                  <EmptyDescription>
+                    No trips found yet. Create your first trip and start packing for your next
+                    adventure.
+                  </EmptyDescription>
+                </EmptyHeader>
+                <EmptyContent>
+                  <Button variant="accent" size="lg" asChild>
+                    <Link to="/trips/new">
+                      <PlusCircle className="h-5 w-5 shrink-0 transition-transform duration-300 group-hover:rotate-90" />
+                      Add new trip
+                    </Link>
+                  </Button>
+                </EmptyContent>
+              </Empty>
 
-                    <span className="truncate">Create a new trip</span>
-                  </Link>
-                </Button>
-              </div>
+              // <div className="mx-auto flex max-w-md flex-col items-center space-y-8 text-center">
+              //   <Logo className="size-16" fill="var(--muted-foreground)" />
+              //   <h2 className="text-2xl font-bold">Welcome, adventurer!</h2>
+              //   <p>
+              //     No trips found yet. Create your first trip and start packing for your next
+              //     adventure.
+              //   </p>
+              //   <Button asChild variant="accent" className="group">
+              //     <Link to="/trips/new">
+              //       <PlusCircle className="h-5 w-5 shrink-0 transition-transform duration-300 group-hover:rotate-90" />
+
+              //       <span className="truncate">Create a new trip</span>
+              //     </Link>
+              //   </Button>
+              // </div>
             )}
           </div>
         </div>

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -4,6 +4,7 @@ export type User = {
   bio?: string
   displayName: string
   email: string
+  isAnonymous?: boolean
   emergencyContacts?: Array<{ name: string; email: string; phoneNumber: string }>
   isAdmin?: boolean
   location?: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import netlify from '@netlify/vite-plugin'
 
 export default defineConfig({
   server: {
-    open: true,
+    open: false,
   },
   ssr: {
     noExternal: ['use-sound'],


### PR DESCRIPTION
## Summary
- Adds `/get-started` route that signs users in anonymously and routes them into trip creation, with a "Try it free — no account needed" CTA on the home page
- Signup now links anonymous credentials via `linkWithCredential` so trips created during the trial persist after account creation
- Anonymous users see `UpgradeAccountGate` on friends/gear-closet/profile and an amber warning on the signin form clarifying that signing in won't transfer their session data
- Adds `isAnonymous` to the User type, a `useIsAnonymous` hook, and skips analytics `identify` for anonymous users

## Test plan
- [ ] Click "Try it free" → lands on /trips/new with anonymous session
- [ ] Create trip anonymously, then sign up → trip is preserved under new account
- [ ] Anonymous user visits /friends, /gear-closet, /profile → sees upgrade gate
- [ ] Anonymous user visits /signin → sees amber warning about session data
- [ ] Existing signup flow (no anonymous session) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)