### PR TITLE
feat: show locked Account Gate for custom tags in Gear Closet (#18)

### DIFF
--- a/app/components/GearCloset/ManageCustomTagsDialog.test.tsx
+++ b/app/components/GearCloset/ManageCustomTagsDialog.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/useIsAnonymous', () => ({
+  useIsAnonymous: vi.fn(),
+}))
+
+vi.mock('../../services/gear', () => ({
+  useGearClosetQuery: vi.fn(() => ({ data: { customTags: [] } })),
+  useCreateCustomTag: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useUpdateCustomTag: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useDeleteCustomTag: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}))
+
+import { useIsAnonymous } from '../../lib/useIsAnonymous'
+import ManageCustomTagsDialog from './ManageCustomTagsDialog'
+
+const GATE_MESSAGE = 'Create an account to add custom categories to your gear closet.'
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <ManageCustomTagsDialog userId="u1">
+        <button>Custom Tags</button>
+      </ManageCustomTagsDialog>
+    </MemoryRouter>
+  )
+}
+
+describe('ManageCustomTagsDialog', () => {
+  it('shows the trigger button for anonymous users', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderComponent()
+    expect(screen.getByRole('button', { name: /custom tags/i })).toBeInTheDocument()
+  })
+
+  it('opens Account Gate modal when anonymous user clicks the button', async () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: /custom tags/i }))
+    expect(screen.getByText(GATE_MESSAGE)).toBeInTheDocument()
+  })
+
+  it('shows "Create account" CTA linking to /signup in the gate modal', async () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: /custom tags/i }))
+    expect(screen.getByRole('link', { name: /create account/i })).toHaveAttribute('href', '/signup')
+  })
+
+  it('opens the full custom tags dialog for registered users', async () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    renderComponent()
+    await userEvent.click(screen.getByRole('button', { name: /custom tags/i }))
+    expect(screen.getByText('Custom tags')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('New tag name...')).toBeInTheDocument()
+  })
+})

--- a/app/components/GearCloset/ManageCustomTagsDialog.tsx
+++ b/app/components/GearCloset/ManageCustomTagsDialog.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, Pencil, Trash2 } from 'lucide-react'
 import { useState } from 'react'
 
+import { AccountGateDialog } from '~/components/AccountGateDialog'
 import { Button } from '~/components/ui/button'
 import {
   Dialog,
@@ -14,6 +15,7 @@ import { Input } from '~/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '~/components/ui/popover'
 import { allPredefinedTags } from '~/lib/gearListItemEnum'
 import { TAG_COLOR_KEYS, type TagColorKey } from '~/lib/tagColors'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
 import {
   useCreateCustomTag,
@@ -90,6 +92,9 @@ function ColorPickerDropdown({
 }
 
 function ManageCustomTagsDialog({ userId, children }: ManageCustomTagsDialogProps) {
+  const isAnonymous = useIsAnonymous()
+  const [gateOpen, setGateOpen] = useState(false)
+
   const { data: closet } = useGearClosetQuery({ userId, queryOptions: { enabled: !!userId } })
   const customTags = closet?.customTags ?? []
 
@@ -173,6 +178,19 @@ function ManageCustomTagsDialog({ userId, children }: ManageCustomTagsDialogProp
     fuchsia: 'bg-fuchsia-500',
     pink: 'bg-pink-500',
     rose: 'bg-rose-500',
+  }
+
+  if (isAnonymous) {
+    return (
+      <>
+        <span onClick={() => setGateOpen(true)}>{children}</span>
+        <AccountGateDialog
+          open={gateOpen}
+          onOpenChange={setGateOpen}
+          message="Create an account to add custom categories to your gear closet."
+        />
+      </>
+    )
   }
 
   return (

--- a/app/routes/gear-closet.tsx
+++ b/app/routes/gear-closet.tsx
@@ -96,45 +96,49 @@ export default function GearCloset() {
     <>
       <PageHeader crumbs={[{ label: 'Gear Closet', href: '/gear-closet' }]} />
       <PageContent>
-        {isAnonymous ? (
-          <UpgradeAccountGate message="Create an account to build your personal gear closet">
-            <div />
-          </UpgradeAccountGate>
-        ) : isLoading ? (
-          <FullPageSpinner what="gear closet" />
-        ) : (
-          <div className="mx-auto max-w-3xl space-y-4">
-            <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <h2 className="text-2xl font-bold">Gear Closet</h2>
-              <div className="flex flex-wrap gap-2">
+        <div className="mx-auto max-w-3xl space-y-4">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <h2 className="text-2xl font-bold">Gear Closet</h2>
+            <div className="flex flex-wrap gap-2">
+              {!isAnonymous && (
                 <ManageTagsDialog userId={userId} currentTags={categories}>
                   <Button variant="outline" size="sm">
                     <Settings2 className="mr-1 h-4 w-4" />
                     Tags
                   </Button>
                 </ManageTagsDialog>
-                <ManageCustomTagsDialog userId={userId}>
-                  <Button variant="outline" size="sm">
-                    <Tags className="mr-1 h-4 w-4" />
-                    Custom Tags
-                  </Button>
-                </ManageCustomTagsDialog>
+              )}
+              <ManageCustomTagsDialog userId={userId}>
+                <Button variant="outline" size="sm">
+                  <Tags className="mr-1 h-4 w-4" />
+                  Custom Tags
+                </Button>
+              </ManageCustomTagsDialog>
+              {!isAnonymous && (
                 <AddGearClosetItemDialog userId={userId}>
                   <Button size="sm">
                     <Plus className="mr-1 h-4 w-4" />
                     Add item
                   </Button>
                 </AddGearClosetItemDialog>
-              </div>
+              )}
             </div>
+          </div>
 
+          {isAnonymous ? (
+            <UpgradeAccountGate message="Create an account to build your personal gear closet">
+              <div />
+            </UpgradeAccountGate>
+          ) : isLoading ? (
+            <FullPageSpinner what="gear closet" />
+          ) : (
             <GearClosetList
               userId={userId}
               masterItems={filteredMasterItems}
               additions={closetAdditions}
             />
-          </div>
-        )}
+          )}
+        </div>
       </PageContent>
     </>
   )


### PR DESCRIPTION
Parent PRD: #12 — Anonymous User UX: Copy Changes & Feature Gating

- ManageCustomTagsDialog checks useIsAnonymous() and renders AccountGateDialog with gate copy when anonymous, full dialog when registered
- Gear closet route restructured: header + Custom Tags button always visible, Tags and Add item buttons hidden for anonymous, gear list gated with UpgradeAccountGate
- 4 component tests covering anonymous gate + registered behavior

Files changed:
- app/components/GearCloset/ManageCustomTagsDialog.tsx
- app/components/GearCloset/ManageCustomTagsDialog.test.tsx (new)
- app/routes/gear-closet.tsx