### PR TITLE
feat: gate Shopping List route for Anonymous Users (#16)

### DIFF
--- a/app/routes/shopping-list.test.tsx
+++ b/app/routes/shopping-list.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/useIsAnonymous', () => ({
+  useIsAnonymous: vi.fn(),
+}))
+
+vi.mock('../contexts/auth/useAuth', () => ({
+  default: vi.fn(() => ({ user: { uid: 'test-uid' } })),
+}))
+
+vi.mock('../services/shoppingList', () => ({
+  useShoppingListQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}))
+
+vi.mock('../services/trips', () => ({
+  useTripsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+}))
+
+vi.mock('../lib/useCheckboxSounds', () => ({
+  useCheckboxSounds: vi.fn(() => ({})),
+}))
+
+import { useIsAnonymous } from '../lib/useIsAnonymous'
+import ShoppingList from './shopping-list'
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <ShoppingList />
+    </MemoryRouter>
+  )
+}
+
+describe('ShoppingList route', () => {
+  it('shows Account Gate for anonymous users with correct copy', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderRoute()
+    expect(
+      screen.getByText(
+        'Create an account to see everything you need to buy before your trips.'
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /create account/i })).toHaveAttribute(
+      'href',
+      '/signup'
+    )
+  })
+
+  it('does not show shopping list content for anonymous users', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderRoute()
+    expect(screen.queryByText('Current')).not.toBeInTheDocument()
+    expect(screen.queryByText('Past')).not.toBeInTheDocument()
+  })
+
+  it('shows shopping list content for registered users', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    renderRoute()
+    expect(screen.getByText('Current')).toBeInTheDocument()
+    expect(screen.getByText('Past')).toBeInTheDocument()
+    expect(
+      screen.queryByText(
+        'Create an account to see everything you need to buy before your trips.'
+      )
+    ).not.toBeInTheDocument()
+  })
+})

--- a/app/routes/shopping-list.tsx
+++ b/app/routes/shopping-list.tsx
@@ -8,9 +8,11 @@ import PageHeader from '~/components/PageHeader'
 import ShoppingListCategory from '~/components/ShoppingList/ShoppingListCategory'
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '~/components/ui/empty'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
+import { UpgradeAccountGate } from '~/components/UpgradeAccountGate'
 import useAuth from '~/contexts/auth/useAuth'
 import { isBeforeToday } from '~/lib/date'
 import { useCheckboxSounds } from '~/lib/useCheckboxSounds'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { useShoppingListQuery } from '~/services/shoppingList'
 import { useTripsQuery } from '~/services/trips'
 import { TripMemberStatus } from '~/types/TripMember'
@@ -23,6 +25,7 @@ export function meta({}: Route.MetaArgs) {
 
 export default function ShoppingList() {
   const { user } = useAuth()
+  const isAnonymous = useIsAnonymous()
   const checkboxSounds = useCheckboxSounds()
 
   const constraints = useMemo(
@@ -124,83 +127,89 @@ export default function ShoppingList() {
     <>
       <PageHeader crumbs={[{ label: 'Shopping List', href: '/shopping-list' }]} />
       <PageContent>
-        <div className="">
-          <div className="mx-auto w-full max-w-4xl">
-            <div>
-              <Tabs defaultValue="current">
-                <TabsList>
-                  <TabsTrigger value="current">Current</TabsTrigger>
-                  <TabsTrigger value="past">Past</TabsTrigger>
-                </TabsList>
-                {(isLoadingTrips || isLoading) && <FullPageSpinner what="shopping list" />}
-                {!isLoading && !isLoadingTrips && (shoppingList?.length ?? 0) > 0 ? (
-                  <>
-                    <TabsContent value="current">
-                      {currentTrips.length > 0 ? (
-                        currentTrips.map(([tripId, items]) => (
-                          <ShoppingListCategory
-                            trip={trips?.find((trip) => trip.tripId === tripId)!}
-                            items={items ?? []}
-                            key={tripId}
-                            sounds={checkboxSounds}
-                          />
-                        ))
-                      ) : (
-                        <Empty>
-                          <EmptyHeader>
-                            <EmptyMedia variant="icon">
-                              <ShoppingCart />
-                            </EmptyMedia>
-                            <EmptyTitle>Your current shopping list is empty</EmptyTitle>
-                            <EmptyDescription>
-                              You have no current shopping list items to display
-                            </EmptyDescription>
-                          </EmptyHeader>
-                        </Empty>
-                      )}
-                    </TabsContent>
-                    <TabsContent value="past">
-                      {pastTrips.length > 0 ? (
-                        pastTrips.map(([tripId, items]) => (
-                          <ShoppingListCategory
-                            trip={trips?.find((trip) => trip.tripId === tripId)!}
-                            items={items ?? []}
-                            key={tripId}
-                            sounds={checkboxSounds}
-                          />
-                        ))
-                      ) : (
-                        <Empty>
-                          <EmptyHeader>
-                            <EmptyMedia variant="icon">
-                              <ShoppingCart />
-                            </EmptyMedia>
-                            <EmptyTitle>Your past shopping list is empty</EmptyTitle>
-                            <EmptyDescription>
-                              You have no past shopping list items to display
-                            </EmptyDescription>
-                          </EmptyHeader>
-                        </Empty>
-                      )}
-                    </TabsContent>
-                  </>
-                ) : (
-                  <Empty>
-                    <EmptyHeader>
-                      <EmptyMedia variant="icon">
-                        <ShoppingCart />
-                      </EmptyMedia>
-                      <EmptyTitle>Your shopping list is empty</EmptyTitle>
-                      <EmptyDescription>
-                        You have no current or past shopping list items to display
-                      </EmptyDescription>
-                    </EmptyHeader>
-                  </Empty>
-                )}
-              </Tabs>
+        {isAnonymous ? (
+          <UpgradeAccountGate message="Create an account to see everything you need to buy before your trips.">
+            <div />
+          </UpgradeAccountGate>
+        ) : (
+          <div className="">
+            <div className="mx-auto w-full max-w-4xl">
+              <div>
+                <Tabs defaultValue="current">
+                  <TabsList>
+                    <TabsTrigger value="current">Current</TabsTrigger>
+                    <TabsTrigger value="past">Past</TabsTrigger>
+                  </TabsList>
+                  {(isLoadingTrips || isLoading) && <FullPageSpinner what="shopping list" />}
+                  {!isLoading && !isLoadingTrips && (shoppingList?.length ?? 0) > 0 ? (
+                    <>
+                      <TabsContent value="current">
+                        {currentTrips.length > 0 ? (
+                          currentTrips.map(([tripId, items]) => (
+                            <ShoppingListCategory
+                              trip={trips?.find((trip) => trip.tripId === tripId)!}
+                              items={items ?? []}
+                              key={tripId}
+                              sounds={checkboxSounds}
+                            />
+                          ))
+                        ) : (
+                          <Empty>
+                            <EmptyHeader>
+                              <EmptyMedia variant="icon">
+                                <ShoppingCart />
+                              </EmptyMedia>
+                              <EmptyTitle>Your current shopping list is empty</EmptyTitle>
+                              <EmptyDescription>
+                                You have no current shopping list items to display
+                              </EmptyDescription>
+                            </EmptyHeader>
+                          </Empty>
+                        )}
+                      </TabsContent>
+                      <TabsContent value="past">
+                        {pastTrips.length > 0 ? (
+                          pastTrips.map(([tripId, items]) => (
+                            <ShoppingListCategory
+                              trip={trips?.find((trip) => trip.tripId === tripId)!}
+                              items={items ?? []}
+                              key={tripId}
+                              sounds={checkboxSounds}
+                            />
+                          ))
+                        ) : (
+                          <Empty>
+                            <EmptyHeader>
+                              <EmptyMedia variant="icon">
+                                <ShoppingCart />
+                              </EmptyMedia>
+                              <EmptyTitle>Your past shopping list is empty</EmptyTitle>
+                              <EmptyDescription>
+                                You have no past shopping list items to display
+                              </EmptyDescription>
+                            </EmptyHeader>
+                          </Empty>
+                        )}
+                      </TabsContent>
+                    </>
+                  ) : (
+                    <Empty>
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <ShoppingCart />
+                        </EmptyMedia>
+                        <EmptyTitle>Your shopping list is empty</EmptyTitle>
+                        <EmptyDescription>
+                          You have no current or past shopping list items to display
+                        </EmptyDescription>
+                      </EmptyHeader>
+                    </Empty>
+                  )}
+                </Tabs>
+              </div>
             </div>
           </div>
-        </div>
+        )}
       </PageContent>
     </>
   )


### PR DESCRIPTION
Parent PRD: #12 — Anonymous User UX: Copy Changes & Feature Gating

- Wrap Shopping List page content with UpgradeAccountGate for anonymous users
- Gate copy: "Create an account to see everything you need to buy before your trips."
- CTA: "Create account" linking to /signup
- Registered users see the Shopping List page unchanged
- Added 3 tests covering gate display, content suppression, and registered user passthrough

Files changed:
- app/routes/shopping-list.tsx (gate logic + UpgradeAccountGate wrapper)
- app/routes/shopping-list.test.tsx (new — 3 tests)