### PR TITLE
chore: data model changes for Safety Itinerary and Leave Trip (#23)

### DIFF
--- a/app/types/TripMember.test.ts
+++ b/app/types/TripMember.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { TripMemberStatus, type TripMember } from './TripMember'
+import type { User } from './User'
+
+describe('TripMemberStatus enum', () => {
+  it('includes Left status', () => {
+    expect(TripMemberStatus.Left).toBe('Left')
+  })
+})
+
+describe('TripMember type', () => {
+  it('accepts safetyItineraryOptedOut as optional boolean', () => {
+    const member: TripMember = {
+      invitedAt: {} as TripMember['invitedAt'],
+      status: TripMemberStatus.Accepted,
+      uid: 'user-1',
+    }
+    expect(member.safetyItineraryOptedOut).toBeUndefined()
+
+    const optedOut: TripMember = {
+      ...member,
+      safetyItineraryOptedOut: true,
+    }
+    expect(optedOut.safetyItineraryOptedOut).toBe(true)
+  })
+})
+
+describe('User.preferences type', () => {
+  it('accepts safetyItineraryEnabled as optional boolean', () => {
+    const user: User = {
+      displayName: 'Test',
+      email: 'test@example.com',
+      uid: 'u1',
+      id: 'u1',
+      username: 'testuser',
+      preferences: {
+        safetyItineraryEnabled: false,
+      },
+    }
+    expect(user.preferences?.safetyItineraryEnabled).toBe(false)
+
+    const defaultUser: User = {
+      displayName: 'Test',
+      email: 'test@example.com',
+      uid: 'u2',
+      id: 'u2',
+      username: 'testuser2',
+      preferences: {},
+    }
+    expect(defaultUser.preferences?.safetyItineraryEnabled).toBeUndefined()
+  })
+})

--- a/app/types/TripMember.ts
+++ b/app/types/TripMember.ts
@@ -11,6 +11,8 @@ export enum TripMemberStatus {
   Declined = 'Declined',
   /** Removed by trip owner */
   Removed = 'Removed',
+  /** Member voluntarily left the trip */
+  Left = 'Left',
 }
 
 export type TripMember = {
@@ -18,6 +20,7 @@ export type TripMember = {
   declinedAt?: Timestamp
   acceptedAt?: Timestamp
   removedAt?: Timestamp
+  safetyItineraryOptedOut?: boolean
   status: TripMemberStatus
   uid: string
   invitedBy?: string

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -21,6 +21,7 @@ export type User = {
     theme?: 'light' | 'dark'
     hasSeenPackingListTour?: boolean
     hasDismissedFernwoodAd?: Timestamp
+    safetyItineraryEnabled?: boolean
     temperatureUnit?: 'celsius' | 'fahrenheit'
   }
 }


### PR DESCRIPTION
Parent PRD: #21 — Safety Itinerary

- Added `Left = 'Left'` to `TripMemberStatus` enum for voluntary member departure
- Added `safetyItineraryOptedOut?: boolean` to `TripMember` type for per-trip opt-out
- Added `safetyItineraryEnabled?: boolean` to `User.preferences` for global opt-out
- Added type-level tests verifying all three additions compile and hold correct values
- `pnpm typecheck` and `pnpm test` pass with no new errors

Files changed:
- app/types/TripMember.ts
- app/types/User.ts
- app/types/TripMember.test.ts (new)