### PR TITLE
feat: update Trip Settings modal copy (#33)

### DIFF
--- a/app/components/Trip/TripSettings.test.tsx
+++ b/app/components/Trip/TripSettings.test.tsx
@@ -263,5 +263,45 @@ describe('TripSettings', () => {
       expect(screen.getByText(/globally disabled/i)).toBeInTheDocument()
       expect(screen.getByRole('link', { name: /settings/i })).toHaveAttribute('href', '/settings')
     })
+
+    it('shows help text describing what the safety itinerary does', async () => {
+      const user = userEvent.setup()
+      renderAsMember()
+      await user.click(screen.getByRole('button', { name: /trip settings/i }))
+      expect(screen.getByText(/email.*day before/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('delete trip copy', () => {
+    it('warns that deleting removes the trip for everyone when multiple active members', async () => {
+      const user = userEvent.setup()
+      renderAsOwner()
+      await user.click(screen.getByRole('button', { name: /trip settings/i }))
+      expect(screen.getByText(/delete.*for all members/i)).toBeInTheDocument()
+    })
+
+    it('does not show multi-member warning when owner is the only active member', async () => {
+      const user = userEvent.setup()
+      renderAsOwner({
+        tripMembers: {
+          'owner-uid': { uid: 'owner-uid', status: TripMemberStatus.Owner, invitedAt: ts },
+        },
+      })
+      await user.click(screen.getByRole('button', { name: /trip settings/i }))
+      expect(screen.queryByText(/delete.*for all members/i)).not.toBeInTheDocument()
+    })
+
+    it('does not count Left or Declined members as active', async () => {
+      const user = userEvent.setup()
+      renderAsOwner({
+        tripMembers: {
+          'owner-uid': { uid: 'owner-uid', status: TripMemberStatus.Owner, invitedAt: ts },
+          'left-uid': { uid: 'left-uid', status: TripMemberStatus.Left, invitedAt: ts },
+          'declined-uid': { uid: 'declined-uid', status: TripMemberStatus.Declined, invitedAt: ts },
+        },
+      })
+      await user.click(screen.getByRole('button', { name: /trip settings/i }))
+      expect(screen.queryByText(/delete.*for all members/i)).not.toBeInTheDocument()
+    })
   })
 })

--- a/app/components/Trip/TripSettings.tsx
+++ b/app/components/Trip/TripSettings.tsx
@@ -34,6 +34,10 @@ export function TripSettings({ trip }: { trip: Trip }) {
   const currentMember = user?.uid ? trip.tripMembers[user.uid] : undefined
   const globalOptOut = user?.preferences?.safetyItineraryEnabled === false
   const isOptedOut = currentMember?.safetyItineraryOptedOut ?? false
+  const activeMemberCount = Object.values(trip.tripMembers).filter(
+    (m) => m.status !== TripMemberStatus.Left && m.status !== TripMemberStatus.Declined && m.status !== TripMemberStatus.Removed,
+  ).length
+  const hasOtherMembers = activeMemberCount > 1
 
   const updateCurrentMember = async (fields: Partial<TripMember>) => {
     if (!user?.uid || !currentMember) return
@@ -83,15 +87,19 @@ export function TripSettings({ trip }: { trip: Trip }) {
             />
             <div className="grid gap-1">
               <Label htmlFor="safety-itinerary">Safety Itinerary</Label>
-              {globalOptOut && (
-                <p className="text-muted-foreground text-xs">
-                  Safety Itinerary is globally disabled. Go to{' '}
-                  <Link to="/settings" className="underline">
-                    Settings
-                  </Link>{' '}
-                  to enable it.
-                </p>
-              )}
+              <p className="text-muted-foreground text-xs">
+                {globalOptOut ? (
+                  <>
+                    Safety Itinerary is globally disabled. Go to{' '}
+                    <Link to="/settings" className="underline">
+                      Settings
+                    </Link>{' '}
+                    to enable it.
+                  </>
+                ) : (
+                  'When enabled, an email with trip details, members, and emergency contacts will be sent the day before your trip starts.'
+                )}
+              </p>
             </div>
           </div>
 
@@ -101,7 +109,10 @@ export function TripSettings({ trip }: { trip: Trip }) {
             <div className="space-y-3">
               <h4 className="text-destructive text-sm font-medium">Delete Trip</h4>
               <p className="text-muted-foreground text-sm">
-                This will permanently delete &ldquo;{trip.name}&rdquo;. This action cannot be undone.
+                This will permanently delete &ldquo;{trip.name}&rdquo;.{' '}
+                {hasOtherMembers
+                  ? 'This will delete the trip for all members.'
+                  : 'This action cannot be undone.'}
               </p>
               <Input
                 placeholder="Type DELETE to confirm"


### PR DESCRIPTION
Parent PRD: #21 — Safety Itinerary

- Safety Itinerary toggle now shows help text describing the email sent the day before the trip with details, members, and contacts
- Delete Trip warns "for all members" when multiple active members exist
- Inactive members (Left, Declined, Removed) excluded from member count
- Leave Trip copy unchanged per requirements
- 4 new tests: help text, multi-member warning, solo-owner, inactive filter

Files changed:
- app/components/Trip/TripSettings.tsx (copy + activeMemberCount logic)
- app/components/Trip/TripSettings.test.tsx (4 new tests)