### PR TITLE
refactor: Issues 34 (update Shared Types) and 35 (preferences layout)

### DIFF
--- a/app/components/SafetyItineraryToggle.test.tsx
+++ b/app/components/SafetyItineraryToggle.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
 import { MemoryRouter } from 'react-router'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -19,6 +20,10 @@ vi.mock('../services/users', () => ({
   useUpdateUser: vi.fn(() => ({
     mutateAsync: mockUpdateUserAsync,
   })),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
 }))
 
 import { useAuth } from '../contexts/auth/useAuth'
@@ -48,9 +53,9 @@ describe('SafetyItineraryToggle', () => {
       mockUpdateUserAsync.mockReset()
     })
 
-    it('shows the Safety Itinerary label', () => {
+    it('renders the switch', () => {
       renderComponent()
-      expect(screen.getByText('Safety Itinerary')).toBeInTheDocument()
+      expect(screen.getByRole('switch')).toBeInTheDocument()
     })
 
     it('defaults to on (opted in) when safetyItineraryEnabled is absent', () => {
@@ -122,6 +127,42 @@ describe('SafetyItineraryToggle', () => {
       expect(mockUpdateUserAsync).toHaveBeenCalledWith({
         data: { preferences: { safetyItineraryEnabled: true } },
       })
+    })
+
+    it('shows success toast when toggling off', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { safetyItineraryEnabled: true },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'You will no longer receive Safety Itinerary emails'
+      )
+    })
+
+    it('shows success toast when toggling on', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { safetyItineraryEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'You will now receive Safety Itinerary emails the day before a trip'
+      )
     })
   })
 })

--- a/app/components/SafetyItineraryToggle.tsx
+++ b/app/components/SafetyItineraryToggle.tsx
@@ -1,3 +1,5 @@
+import { toast } from 'sonner'
+
 import { useAuth } from '~/contexts/auth/useAuth'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { useUpdateUser } from '~/services/users'
@@ -14,26 +16,29 @@ export function SafetyItineraryToggle() {
   const enabled = user?.preferences?.safetyItineraryEnabled !== false
 
   const handleToggle = () => {
+    const newValue = !enabled
     updateUserAsync({
-      data: { preferences: { safetyItineraryEnabled: !enabled } },
+      data: { preferences: { safetyItineraryEnabled: newValue } },
     })
+    toast.success(
+      newValue
+        ? 'You will now receive Safety Itinerary emails the day before a trip'
+        : 'You will no longer receive Safety Itinerary emails'
+    )
   }
 
   return (
-    <div className="flex items-center">
-      <span className="mr-5">Safety Itinerary</span>
-      <button
-        role="switch"
-        type="button"
-        aria-checked={enabled}
-        aria-label="Toggle Safety Itinerary"
-        onClick={handleToggle}
-        className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${enabled ? 'bg-primary' : 'bg-input'}`}
-      >
-        <span
-          className={`pointer-events-none block size-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0'}`}
-        />
-      </button>
-    </div>
+    <button
+      role="switch"
+      type="button"
+      aria-checked={enabled}
+      aria-label="Toggle Safety Itinerary"
+      onClick={handleToggle}
+      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors ${enabled ? 'bg-primary' : 'bg-input'}`}
+    >
+      <span
+        className={`pointer-events-none block size-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${enabled ? 'translate-x-5' : 'translate-x-0'}`}
+      />
+    </button>
   )
 }

--- a/app/components/SoundsToggle.tsx
+++ b/app/components/SoundsToggle.tsx
@@ -18,30 +18,27 @@ export function SoundsToggle() {
   const [style, trigger] = useBoop({ scale: 1.1, rotation: 10 })
 
   return (
-    <div className="flex items-center">
-      <span className="mr-5">Sounds</span>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <animated.button
-              style={style}
-              onMouseEnter={trigger as MouseEventHandler<HTMLButtonElement>}
-              type="button"
-              aria-label="Toggle sounds"
-              onClick={() => {
-                if (!soundsEnabled) {
-                  switchOn()
-                }
-                toggleSounds()
-              }}
-              className="rounded-md p-1 focus:bg-gray-100 focus:outline-none md:first-letter:p-2 dark:focus:bg-gray-800"
-            >
-              {soundsEnabled ? <Volume2 /> : <VolumeX />}
-            </animated.button>
-          </TooltipTrigger>
-          <TooltipContent>Toggle sounds</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    </div>
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <animated.button
+            style={style}
+            onMouseEnter={trigger as MouseEventHandler<HTMLButtonElement>}
+            type="button"
+            aria-label="Toggle sounds"
+            onClick={() => {
+              if (!soundsEnabled) {
+                switchOn()
+              }
+              toggleSounds()
+            }}
+            className="rounded-md p-1 focus:bg-gray-100 focus:outline-none md:first-letter:p-2 dark:focus:bg-gray-800"
+          >
+            {soundsEnabled ? <Volume2 /> : <VolumeX />}
+          </animated.button>
+        </TooltipTrigger>
+        <TooltipContent>Toggle sounds</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }

--- a/app/components/ThemeToggle.tsx
+++ b/app/components/ThemeToggle.tsx
@@ -47,8 +47,7 @@ export function ThemeToggle() {
   }
 
   return (
-    <Form method="post" action="/resource/toggle-theme" className="flex items-center">
-      <span className="mr-5">Display Theme</span>
+    <Form method="post" action="/resource/toggle-theme">
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/app/emails/safety-itinerary.tsx
+++ b/app/emails/safety-itinerary.tsx
@@ -1,7 +1,7 @@
 import { Column, Hr, Link, Row, Section, Text } from '@react-email/components'
 
-import { TripMemberStatus } from '../types/TripMember'
 import type { SafetyItineraryEmailProps } from '../types/SafetyItinerary'
+import { TripMemberStatus } from '../types/TripMember'
 import BaseEmailTemplate from './base'
 
 export const SafetyItineraryEmail = ({

--- a/app/emails/safety-itinerary.tsx
+++ b/app/emails/safety-itinerary.tsx
@@ -1,28 +1,8 @@
 import { Column, Hr, Link, Row, Section, Text } from '@react-email/components'
 
 import { TripMemberStatus } from '../types/TripMember'
+import type { SafetyItineraryEmailProps } from '../types/SafetyItinerary'
 import BaseEmailTemplate from './base'
-
-interface SafetyItineraryMember {
-  displayName: string
-  status: TripMemberStatus
-}
-
-interface EmergencyContact {
-  name: string
-  phoneNumber: string
-  email: string
-}
-
-interface SafetyItineraryEmailProps {
-  tripName: string
-  startingPoint: string
-  dateRange: string
-  description: string
-  members: SafetyItineraryMember[]
-  emergencyContacts: EmergencyContact[]
-  url: string
-}
 
 export const SafetyItineraryEmail = ({
   tripName,

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -11,14 +11,54 @@ export function meta({}: Route.MetaArgs) {
   return [{ title: 'Settings | Packup' }]
 }
 
+function PreferenceRow({
+  label,
+  description,
+  children,
+}: {
+  label: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-3">
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">{label}</span>
+        <span className="text-muted-foreground text-sm">{description}</span>
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}
+
 export default function Settings() {
   return (
     <>
       <PageHeader crumbs={[{ label: 'Settings', href: '/settings' }]} />
       <PageContent>
-        <ThemeToggle />
-        <SoundsToggle />
-        <SafetyItineraryToggle />
+        <section className="max-w-2xl">
+          <h2 className="mb-2 text-lg font-semibold">Preferences</h2>
+          <div className="divide-border divide-y">
+            <PreferenceRow
+              label="Display Theme"
+              description="Switch between light and dark mode"
+            >
+              <ThemeToggle />
+            </PreferenceRow>
+            <PreferenceRow
+              label="Sounds"
+              description="Enable or disable UI sound effects"
+            >
+              <SoundsToggle />
+            </PreferenceRow>
+            <PreferenceRow
+              label="Safety Itinerary"
+              description="Receive an email the day before your trip with details, members, and emergency contacts"
+            >
+              <SafetyItineraryToggle />
+            </PreferenceRow>
+          </div>
+        </section>
         <EmergencyContacts />
       </PageContent>
     </>

--- a/app/types/EmergencyContact.ts
+++ b/app/types/EmergencyContact.ts
@@ -1,0 +1,5 @@
+export type EmergencyContact = {
+  name: string
+  phoneNumber: string
+  email: string
+}

--- a/app/types/SafetyItinerary.ts
+++ b/app/types/SafetyItinerary.ts
@@ -1,0 +1,28 @@
+import type { TripMemberStatus } from './TripMember'
+import type { EmergencyContact } from './EmergencyContact'
+
+export type SafetyItineraryMember = {
+  displayName: string
+  status: TripMemberStatus
+}
+
+export type SafetyItineraryEmailProps = {
+  tripName: string
+  startingPoint: string
+  dateRange: string
+  description: string
+  members: SafetyItineraryMember[]
+  emergencyContacts: EmergencyContact[]
+  url: string
+}
+
+export type SafetyItineraryEmailPayload = {
+  to: string
+  tripName: string
+  startingPoint: string
+  dateRange: string
+  description: string
+  members: SafetyItineraryMember[]
+  emergencyContacts: EmergencyContact[]
+  recipientUid: string
+}

--- a/app/types/SafetyItinerary.ts
+++ b/app/types/SafetyItinerary.ts
@@ -1,5 +1,5 @@
-import type { TripMemberStatus } from './TripMember'
 import type { EmergencyContact } from './EmergencyContact'
+import type { TripMemberStatus } from './TripMember'
 
 export type SafetyItineraryMember = {
   displayName: string

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -1,11 +1,13 @@
 import type { Timestamp } from 'firebase/firestore'
 
+import type { EmergencyContact } from './EmergencyContact'
+
 export type User = {
   bio?: string
   displayName: string
   email: string
   isAnonymous?: boolean
-  emergencyContacts?: Array<{ name: string; email: string; phoneNumber: string }>
+  emergencyContacts?: EmergencyContact[]
   isAdmin?: boolean
   location?: string
   photoURL?: string

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,8 @@
 import * as admin from 'firebase-admin'
 import { onSchedule } from 'firebase-functions/v2/scheduler'
 
-import type { SafetyItineraryEmailPayload } from './safety-itinerary'
+import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
+
 import { buildFirestoreDeps, processSafetyItineraries } from './safety-itinerary'
 import { renderSafetyItineraryHtml } from './render-email'
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,7 +1,7 @@
 import * as admin from 'firebase-admin'
 import { onSchedule } from 'firebase-functions/v2/scheduler'
 
-import type { EmailPayload } from './safety-itinerary'
+import type { SafetyItineraryEmailPayload } from './safety-itinerary'
 import { buildFirestoreDeps, processSafetyItineraries } from './safety-itinerary'
 import { renderSafetyItineraryHtml } from './render-email'
 
@@ -15,7 +15,7 @@ export const sendSafetyItineraries = onSchedule('every day 12:00', async () => {
   if (!apiKey) throw new Error('SENDGRID_API_KEY not configured')
   sgMail.default.setApiKey(apiKey)
 
-  const sendEmail = async (payload: EmailPayload): Promise<void> => {
+  const sendEmail = async (payload: SafetyItineraryEmailPayload): Promise<void> => {
     const html = await renderSafetyItineraryHtml(payload)
 
     await sgMail.default.send({

--- a/functions/src/render-email.test.tsx
+++ b/functions/src/render-email.test.tsx
@@ -1,18 +1,19 @@
 import { describe, expect, it } from 'vitest'
 
-import type { EmailPayload } from './safety-itinerary'
+import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
+import { TripMemberStatus } from '../../app/types/TripMember'
 import { renderSafetyItineraryHtml } from './render-email'
 
-const basePayload: EmailPayload = {
+const basePayload: SafetyItineraryEmailPayload = {
   to: 'alice@example.com',
   tripName: 'Mt. Robson Backpacking',
   startingPoint: 'Berg Lake Trailhead, BC',
   dateRange: 'Jun 15, 2026 – Jun 18, 2026',
   description: 'Three-night trip to Berg Lake via the North Boundary Trail.',
   members: [
-    { displayName: 'Alice', status: 'Owner' },
-    { displayName: 'Bob', status: 'Accepted' },
-    { displayName: 'Charlie', status: 'Pending' },
+    { displayName: 'Alice', status: TripMemberStatus.Owner },
+    { displayName: 'Bob', status: TripMemberStatus.Accepted },
+    { displayName: 'Charlie', status: TripMemberStatus.Pending },
   ],
   emergencyContacts: [
     { name: 'John Doe', phoneNumber: '+1-555-0100', email: 'john@example.com' },

--- a/functions/src/render-email.tsx
+++ b/functions/src/render-email.tsx
@@ -6,15 +6,6 @@ import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerar
 const APP_URL = process.env.APP_URL ?? 'https://getpackup.com'
 
 export async function renderSafetyItineraryHtml(payload: SafetyItineraryEmailPayload): Promise<string> {
-  return render(
-    <SafetyItineraryEmail
-      tripName={payload.tripName}
-      startingPoint={payload.startingPoint}
-      dateRange={payload.dateRange}
-      description={payload.description}
-      members={payload.members}
-      emergencyContacts={payload.emergencyContacts}
-      url={APP_URL}
-    />
-  )
+  const { to, recipientUid, ...emailProps } = payload
+  return render(<SafetyItineraryEmail {...emailProps} url={APP_URL} />)
 }

--- a/functions/src/render-email.tsx
+++ b/functions/src/render-email.tsx
@@ -1,20 +1,18 @@
 import { render } from '@react-email/render'
 
 import { SafetyItineraryEmail } from '../../app/emails/safety-itinerary'
-import type { TripMemberStatus } from '../../app/types/TripMember'
-
-import type { EmailPayload } from './safety-itinerary'
+import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
 
 const APP_URL = process.env.APP_URL ?? 'https://getpackup.com'
 
-export async function renderSafetyItineraryHtml(payload: EmailPayload): Promise<string> {
+export async function renderSafetyItineraryHtml(payload: SafetyItineraryEmailPayload): Promise<string> {
   return render(
     <SafetyItineraryEmail
       tripName={payload.tripName}
       startingPoint={payload.startingPoint}
       dateRange={payload.dateRange}
       description={payload.description}
-      members={payload.members as Array<{ displayName: string; status: TripMemberStatus }>}
+      members={payload.members}
       emergencyContacts={payload.emergencyContacts}
       url={APP_URL}
     />

--- a/functions/src/safety-itinerary.test.ts
+++ b/functions/src/safety-itinerary.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import type { Dependencies, EmailPayload, TripDoc, UserDoc } from './safety-itinerary'
+import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
+import { TripMemberStatus } from '../../app/types/TripMember'
+import type { Dependencies, TripDoc, UserDoc } from './safety-itinerary'
 import { processSafetyItineraries } from './safety-itinerary'
 
 function makeTimestamp(date: Date) {
@@ -22,9 +24,9 @@ function makeTripStartingTomorrow(overrides: Partial<TripDoc> = {}): TripDoc {
     endDate: makeTimestamp(endDate),
     description: 'Three-night trip',
     tripMembers: {
-      'user-owner': { uid: 'user-owner', status: 'Owner' },
-      'user-accepted': { uid: 'user-accepted', status: 'Accepted' },
-      'user-pending': { uid: 'user-pending', status: 'Pending' },
+      'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
+      'user-accepted': { uid: 'user-accepted', status: TripMemberStatus.Accepted },
+      'user-pending': { uid: 'user-pending', status: TripMemberStatus.Pending },
     },
     ...overrides,
   }
@@ -44,7 +46,7 @@ function makeDeps(
   trips: TripDoc[] = [],
   users: Map<string, UserDoc> = new Map()
 ): { deps: Dependencies; sendEmail: ReturnType<typeof vi.fn> } {
-  const sendEmail = vi.fn<(payload: EmailPayload) => Promise<void>>().mockResolvedValue(undefined)
+  const sendEmail = vi.fn<(payload: SafetyItineraryEmailPayload) => Promise<void>>().mockResolvedValue(undefined)
   return {
     deps: {
       getTripsStartingTomorrow: vi.fn().mockResolvedValue(trips),
@@ -59,8 +61,8 @@ describe('processSafetyItineraries', () => {
   it('does not send emails for members with Declined status', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-declined': { uid: 'user-declined', status: 'Declined' },
-        'user-owner': { uid: 'user-owner', status: 'Owner' },
+        'user-declined': { uid: 'user-declined', status: TripMemberStatus.Declined },
+        'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
       },
     })
     const users = new Map([
@@ -78,8 +80,8 @@ describe('processSafetyItineraries', () => {
   it('does not send emails for members with Removed status', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-removed': { uid: 'user-removed', status: 'Removed' },
-        'user-owner': { uid: 'user-owner', status: 'Owner' },
+        'user-removed': { uid: 'user-removed', status: TripMemberStatus.Removed },
+        'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
       },
     })
     const users = new Map([
@@ -97,8 +99,8 @@ describe('processSafetyItineraries', () => {
   it('does not send emails for members with Left status', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-left': { uid: 'user-left', status: 'Left' },
-        'user-owner': { uid: 'user-owner', status: 'Owner' },
+        'user-left': { uid: 'user-left', status: TripMemberStatus.Left },
+        'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
       },
     })
     const users = new Map([
@@ -116,8 +118,8 @@ describe('processSafetyItineraries', () => {
   it('skips members with safetyItineraryOptedOut set to true', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-opted-out': { uid: 'user-opted-out', status: 'Accepted', safetyItineraryOptedOut: true },
-        'user-owner': { uid: 'user-owner', status: 'Owner' },
+        'user-opted-out': { uid: 'user-opted-out', status: TripMemberStatus.Accepted, safetyItineraryOptedOut: true },
+        'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
       },
     })
     const users = new Map([
@@ -136,8 +138,8 @@ describe('processSafetyItineraries', () => {
   it('skips members whose global safetyItineraryEnabled is false', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-global-out': { uid: 'user-global-out', status: 'Accepted' },
-        'user-owner': { uid: 'user-owner', status: 'Owner' },
+        'user-global-out': { uid: 'user-global-out', status: TripMemberStatus.Accepted },
+        'user-owner': { uid: 'user-owner', status: TripMemberStatus.Owner },
       },
     })
     const users = new Map([
@@ -156,7 +158,7 @@ describe('processSafetyItineraries', () => {
   it('sends emails to members with Pending status', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'user-pending': { uid: 'user-pending', status: 'Pending' },
+        'user-pending': { uid: 'user-pending', status: TripMemberStatus.Pending },
       },
     })
     const users = new Map([['user-pending', makeUser('user-pending')]])
@@ -185,8 +187,8 @@ describe('processSafetyItineraries', () => {
   it('includes each recipient their own emergency contacts, not another members', async () => {
     const trip = makeTripStartingTomorrow({
       tripMembers: {
-        'alice': { uid: 'alice', status: 'Owner' },
-        'bob': { uid: 'bob', status: 'Accepted' },
+        'alice': { uid: 'alice', status: TripMemberStatus.Owner },
+        'bob': { uid: 'bob', status: TripMemberStatus.Accepted },
       },
     })
     const aliceContacts = [{ name: 'Alice Mom', phoneNumber: '555-1111', email: 'amom@test.com' }]

--- a/functions/src/safety-itinerary.ts
+++ b/functions/src/safety-itinerary.ts
@@ -1,15 +1,15 @@
 import type { Firestore, Timestamp } from 'firebase-admin/firestore'
 
-export interface TripMember {
-  uid: string
-  status: 'Owner' | 'Accepted' | 'Pending' | 'Declined' | 'Removed' | 'Left'
-  safetyItineraryOptedOut?: boolean
-}
+import type { EmergencyContact } from '../../app/types/EmergencyContact'
+import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
+import { TripMemberStatus } from '../../app/types/TripMember'
 
-export interface EmergencyContact {
-  name: string
-  phoneNumber: string
-  email: string
+export type { SafetyItineraryEmailPayload }
+
+interface TripMember {
+  uid: string
+  status: TripMemberStatus
+  safetyItineraryOptedOut?: boolean
 }
 
 export interface UserDoc {
@@ -33,24 +33,13 @@ export interface TripDoc {
   tripMembers: { [uid: string]: TripMember }
 }
 
-export interface EmailPayload {
-  to: string
-  tripName: string
-  startingPoint: string
-  dateRange: string
-  description: string
-  members: Array<{ displayName: string; status: string }>
-  emergencyContacts: EmergencyContact[]
-  recipientUid: string
-}
-
 export interface Dependencies {
   getTripsStartingTomorrow: () => Promise<TripDoc[]>
   getUsersByUids: (uids: string[]) => Promise<Map<string, UserDoc>>
-  sendEmail: (payload: EmailPayload) => Promise<void>
+  sendEmail: (payload: SafetyItineraryEmailPayload) => Promise<void>
 }
 
-const ELIGIBLE_STATUSES: Set<TripMember['status']> = new Set(['Owner', 'Accepted', 'Pending'])
+const ELIGIBLE_STATUSES = new Set<TripMemberStatus>([TripMemberStatus.Owner, TripMemberStatus.Accepted, TripMemberStatus.Pending])
 
 function formatDateRange(startDate: Timestamp, endDate: Timestamp): string {
   const start = startDate.toDate()
@@ -75,7 +64,7 @@ export async function processSafetyItineraries(deps: Dependencies): Promise<numb
     const usersMap = await deps.getUsersByUids(uids)
 
     const allMembers = members
-      .filter((m) => m.status !== 'Removed')
+      .filter((m) => m.status !== TripMemberStatus.Removed)
       .map((m) => {
         const user = usersMap.get(m.uid)
         return { displayName: user?.displayName ?? 'Unknown', status: m.status }
@@ -108,7 +97,7 @@ export async function processSafetyItineraries(deps: Dependencies): Promise<numb
 
 export function buildFirestoreDeps(
   db: Firestore,
-  sendEmail: (payload: EmailPayload) => Promise<void>
+  sendEmail: (payload: SafetyItineraryEmailPayload) => Promise<void>
 ): Dependencies {
   return {
     getTripsStartingTomorrow: async () => {

--- a/functions/src/safety-itinerary.ts
+++ b/functions/src/safety-itinerary.ts
@@ -4,8 +4,6 @@ import type { EmergencyContact } from '../../app/types/EmergencyContact'
 import type { SafetyItineraryEmailPayload } from '../../app/types/SafetyItinerary'
 import { TripMemberStatus } from '../../app/types/TripMember'
 
-export type { SafetyItineraryEmailPayload }
-
 interface TripMember {
   uid: string
   status: TripMemberStatus

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -13,6 +13,6 @@
     "sourceMap": true,
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "../app/emails/safety-itinerary.tsx", "../app/emails/base.tsx", "../app/types/TripMember.ts"],
+  "include": ["src/**/*", "../app/emails/safety-itinerary.tsx", "../app/emails/base.tsx", "../app/types/TripMember.ts", "../app/types/EmergencyContact.ts", "../app/types/SafetyItinerary.ts"],
   "exclude": ["node_modules", "lib"]
 }


### PR DESCRIPTION
Parent PRD: #21 — Safety Itinerary

Consolidates duplicate type definitions scattered across the email
template, Firebase functions, and User type into canonical exports
in app/types/.

- New EmergencyContact type in app/types/EmergencyContact.ts
- New SafetyItineraryMember, SafetyItineraryEmailProps,
  SafetyItineraryEmailPayload types in app/types/SafetyItinerary.ts
- User.emergencyContacts now uses EmergencyContact type
- Email template imports types from app/types/ instead of local defs
- Functions use TripMemberStatus enum instead of string literals
- render-email.tsx no longer needs type cast (types align naturally)
- UserDoc, TripDoc, Dependencies remain local (function-specific)

Files changed:
- app/types/EmergencyContact.ts (new)
- app/types/SafetyItinerary.ts (new)
- app/types/User.ts (use EmergencyContact)
- app/emails/safety-itinerary.tsx (import from types)
- functions/src/safety-itinerary.ts (import shared types, use enum)
- functions/src/safety-itinerary.test.ts (use TripMemberStatus enum)
- functions/src/render-email.tsx (import from types, remove cast)
- functions/src/render-email.test.tsx (use shared types)
- functions/src/index.ts (rename EmailPayload import)
- functions/tsconfig.json (include new type files)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>