### PR TITLE
feat: Add tagCounts to User type and implement getFrequentTags utility (#40)

### DIFF
--- a/app/components/BottomNav.tsx
+++ b/app/components/BottomNav.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '~/contexts/auth/useAuth'
 import { firebaseAuth } from '~/firebase/config'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
+import { usePendingFriendRequestsQuery } from '~/services/friends'
 
 import {
   Drawer,
@@ -60,6 +61,7 @@ export function BottomNav({ className }: BottomNavProps) {
   const location = useLocation()
   const navigate = useNavigate()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const { data: pendingRequests } = usePendingFriendRequestsQuery(user?.uid ?? '')
 
   const isActive = (href: string) => {
     const basePath = href.split('/')[1]
@@ -210,6 +212,13 @@ export function BottomNav({ className }: BottomNavProps) {
                     >
                       <item.icon className="size-5" />
                       {item.label}
+                      {item.label === 'Friends' &&
+                        pendingRequests &&
+                        pendingRequests.length > 0 && (
+                          <span className="bg-destructive text-destructive-foreground ml-auto flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold">
+                            {pendingRequests.length}
+                          </span>
+                        )}
                     </Link>
                   </DrawerClose>
                 ))}

--- a/app/components/FriendRequestEmailToggle.test.tsx
+++ b/app/components/FriendRequestEmailToggle.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/useIsAnonymous', () => ({
+  useIsAnonymous: vi.fn(),
+}))
+
+const mockUpdateUserAsync = vi.fn()
+
+vi.mock('../contexts/auth/useAuth', () => ({
+  useAuth: vi.fn(() => ({
+    user: { uid: 'u1', username: 'testuser', email: 'test@test.com', preferences: {} },
+  })),
+}))
+
+vi.mock('../services/users', () => ({
+  useUpdateUser: vi.fn(() => ({
+    mutateAsync: mockUpdateUserAsync,
+  })),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
+}))
+
+import { useAuth } from '../contexts/auth/useAuth'
+import { useIsAnonymous } from '../lib/useIsAnonymous'
+import { FriendRequestEmailToggle } from './FriendRequestEmailToggle'
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <FriendRequestEmailToggle />
+    </MemoryRouter>
+  )
+}
+
+describe('FriendRequestEmailToggle', () => {
+  describe('anonymous users', () => {
+    it('does not render for anonymous users', () => {
+      vi.mocked(useIsAnonymous).mockReturnValue(true)
+      const { container } = renderComponent()
+      expect(container.innerHTML).toBe('')
+    })
+  })
+
+  describe('registered users', () => {
+    beforeEach(() => {
+      vi.mocked(useIsAnonymous).mockReturnValue(false)
+      mockUpdateUserAsync.mockReset()
+    })
+
+    it('renders the switch', () => {
+      renderComponent()
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+
+    it('defaults to on (opted in) when friendRequestEmailEnabled is absent', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: { uid: 'u1', username: 'testuser', email: 'test@test.com', preferences: {} },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('defaults to on when preferences is undefined', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: { uid: 'u1', username: 'testuser', email: 'test@test.com' },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('shows off state when friendRequestEmailEnabled is false', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { friendRequestEmailEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+    })
+
+    it('writes friendRequestEmailEnabled = false when toggling off', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { friendRequestEmailEnabled: true },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(mockUpdateUserAsync).toHaveBeenCalledWith({
+        data: { preferences: { friendRequestEmailEnabled: false } },
+      })
+    })
+
+    it('writes friendRequestEmailEnabled = true when toggling on', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { friendRequestEmailEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(mockUpdateUserAsync).toHaveBeenCalledWith({
+        data: { preferences: { friendRequestEmailEnabled: true } },
+      })
+    })
+
+    it('shows success toast when toggling off', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { friendRequestEmailEnabled: true },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'You will no longer receive friend request emails'
+      )
+    })
+
+    it('shows success toast when toggling on', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { friendRequestEmailEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'You will now receive friend request emails'
+      )
+    })
+  })
+})

--- a/app/components/FriendRequestEmailToggle.tsx
+++ b/app/components/FriendRequestEmailToggle.tsx
@@ -1,0 +1,32 @@
+import { toast } from 'sonner'
+
+import { Switch } from '~/components/ui/switch'
+import { useAuth } from '~/contexts/auth/useAuth'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
+import { useUpdateUser } from '~/services/users'
+
+export function FriendRequestEmailToggle() {
+  const isAnonymous = useIsAnonymous()
+  const { user } = useAuth()
+  const { mutateAsync: updateUserAsync } = useUpdateUser(user?.uid ?? '')
+
+  if (isAnonymous) {
+    return null
+  }
+
+  const enabled = user?.preferences?.friendRequestEmailEnabled !== false
+
+  const handleToggle = () => {
+    const newValue = !enabled
+    updateUserAsync({
+      data: { preferences: { friendRequestEmailEnabled: newValue } },
+    })
+    toast.success(
+      newValue
+        ? 'You will now receive friend request emails'
+        : 'You will no longer receive friend request emails'
+    )
+  }
+
+  return <Switch checked={enabled} onCheckedChange={handleToggle} />
+}

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -27,6 +27,7 @@ import { firebaseAuth } from '~/firebase/config'
 import useBoop from '~/lib/useBoop'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { cn } from '~/lib/utils'
+import { usePendingFriendRequestsQuery } from '~/services/friends'
 
 import { Logo } from './Logo'
 import {
@@ -49,6 +50,7 @@ export function Sidebar({ className }: SidebarProps) {
   const { isSidebarCollapsed, setIsSidebarCollapsed } = useSidebarState()
   const [nextStyle, triggerNext] = useBoop({ x: 2 }) as [any, () => void]
   const [animatingItem, setAnimatingItem] = useState<string | null>(null)
+  const { data: pendingRequests } = usePendingFriendRequestsQuery(user?.uid ?? '')
 
   const navigate = useNavigate()
   const location = useLocation()
@@ -158,6 +160,13 @@ export function Sidebar({ className }: SidebarProps) {
 
                   {!isSidebarCollapsed && <span className="truncate">{item.label}</span>}
                 </animated.span>
+                {item.label === 'Friends' &&
+                  pendingRequests &&
+                  pendingRequests.length > 0 && (
+                    <span className="bg-destructive text-destructive-foreground ml-auto flex size-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold">
+                      {pendingRequests.length}
+                    </span>
+                  )}
               </Link>
             </li>
           ))}

--- a/app/components/Trip/AddTripPartyMember.test.tsx
+++ b/app/components/Trip/AddTripPartyMember.test.tsx
@@ -17,6 +17,15 @@ vi.mock('../../services/trips', () => ({
   useCreateChatMessage: vi.fn(() => ({ mutateAsync: vi.fn() })),
 }))
 
+vi.mock('../../services/friends', () => ({
+  useFriendsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useSendFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}))
+
+vi.mock('../../services/users', () => ({
+  useUserByIdQuery: vi.fn(() => ({ data: null })),
+}))
+
 vi.mock('react-router', async () => {
   const actual = await vi.importActual<typeof import('react-router')>('react-router')
   return {

--- a/app/components/Trip/AddTripPartyMember.tsx
+++ b/app/components/Trip/AddTripPartyMember.tsx
@@ -23,12 +23,15 @@ import { createSystemMessage } from '~/lib/chat'
 import { formattedDateRange } from '~/lib/date'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { algoliaSearch } from '~/services/algoliaSearch'
+import { useFriendsQuery, useSendFriendRequest } from '~/services/friends'
 import { useCreateChatMessage, useUpdateTrip } from '~/services/trips'
+import { useUserByIdQuery } from '~/services/users'
 import type { Trip } from '~/types/Trip'
 import { type TripMember, TripMemberStatus } from '~/types/TripMember'
 import type { User } from '~/types/User'
 
 import { Button } from '../ui/button'
+import { Checkbox } from '../ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -40,6 +43,47 @@ import {
 } from '../ui/dialog'
 import UserMediaObject from '../UserMediaObject'
 import TripPartyMemberBadge from './TripPartyMemberBadge'
+
+function FriendInviteRow({
+  friendUid,
+  tripMembers,
+  isAddingMember,
+  onAdd,
+}: {
+  friendUid: string
+  tripMembers: TripMember[]
+  isAddingMember: string | null
+  onAdd: (uid: string, email: string, name: string) => void
+}) {
+  const { data: friendUser } = useUserByIdQuery({ userId: friendUid })
+  const matchingMember = tripMembers.find((m) => m.uid === friendUid)
+
+  if (!friendUser) return null
+
+  return (
+    <div className="text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors">
+      <UserMediaObject user={friendUser} />
+      {matchingMember ? (
+        <TripPartyMemberBadge member={matchingMember} />
+      ) : (
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          onClick={() => onAdd(friendUser.uid, friendUser.email, friendUser.username)}
+          disabled={isAddingMember === friendUser.uid}
+        >
+          {isAddingMember === friendUser.uid ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Plus />
+          )}
+          <span className="sr-only">Add {friendUser.username} to trip</span>
+        </Button>
+      )}
+    </div>
+  )
+}
 
 export function AddTripPartyMember({
   trip,
@@ -55,12 +99,22 @@ export function AddTripPartyMember({
   const { id } = useParams()
   const fetcher = useFetcher()
 
+  const { data: friendships = [] } = useFriendsQuery(user?.uid ?? '')
+  const { mutateAsync: sendFriendReq } = useSendFriendRequest()
+  const [sendFriendRequestFor, setSendFriendRequestFor] = useState<Record<string, boolean>>({})
+
   const [searchValueTimeout, setSearchValueTimeout] = useState<NodeJS.Timeout | null>(null)
   const [isLoadingSearchResults, setIsLoadingSearchResults] = useState(false)
   const [isHydrated, setIsHydrated] = useState(false)
   const [algoliaService, setAlgoliaService] = useState<typeof algoliaSearch | null>(null)
   const [hits, setHits] = useState<SearchResponse<User>['hits']>([])
   const [isAddingMember, setIsAddingMember] = useState<string | null>(null)
+
+  const friendUids = friendships.map((f) =>
+    f.uids.find((uid) => uid !== user?.uid) ?? ''
+  ).filter(Boolean)
+
+  const isFriend = (uid: string) => friendUids.includes(uid)
 
   // Prevent hydration mismatch by only allowing username checking after hydration
   useEffect(() => {
@@ -218,12 +272,15 @@ export function AddTripPartyMember({
                 action: '/resource/send-trip-invitation',
               }
             )
-            .then(() => {
+            .then(async () => {
               toast.success(`${hitName} has been invited to the trip`)
-              // trackEvent('Trip Party Search User Added', {
-              //   tripId: id,
-              //   ...payload,
-              // })
+              if (sendFriendRequestFor[hitUserId] && user.uid) {
+                try {
+                  await sendFriendReq({ senderUid: user.uid, recipientUid: hitUserId })
+                } catch {
+                  // Friend request is independent — don't block the trip invite
+                }
+              }
             })
             .catch((err) => {
               toast.error(err.message)
@@ -288,87 +345,125 @@ export function AddTripPartyMember({
         </>
       </PopoverTrigger>
       <PopoverContent className="w-80">
-        <Form {...form}>
-          <form className="space-y-8">
+        <div className="space-y-4">
+          {friendUids.length > 0 && (
             <div className="space-y-2">
-              <FormField
-                control={form.control}
-                name="searchValue"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Add trip party member</FormLabel>
-                    <FormControl>
-                      <Input
-                        placeholder="Search by username, email, or name..."
-                        {...field}
-                        onChange={(e) => {
-                          field.onChange(e)
-                          handleSearchValueChange(e)
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                    <FormDescription className="text-center">
-                      {isLoadingSearchResults && hits.length === 0 && (
-                        <span>
-                          <Loader2 className="mr-2 inline size-4 animate-spin" />
-                          Searching...
-                        </span>
-                      )}
-                      {!isLoadingSearchResults &&
-                        form.getValues('searchValue') !== '' &&
-                        form.getValues('searchValue').length >= 2 &&
-                        hits &&
-                        hits.length === 0 && (
-                          <span>
-                            No results found.{' '}
-                            <span
-                              className="text-primary cursor-pointer"
-                              onClick={() => form.reset()}
-                            >
-                              Clear search
-                            </span>
-                          </span>
-                        )}
-                    </FormDescription>
-                  </FormItem>
-                )}
-              />
-              <div className="max-h-[200px] space-y-2 overflow-y-auto">
-                {hits.length > 0 &&
-                  hits.map((hit) => {
-                    const matchingUser = tripMembers.find((member) => member.uid === hit.uid)
-                    return (
-                      <div
-                        key={hit.objectID}
-                        className="text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors"
-                      >
-                        <UserMediaObject user={hit} />
-                        {matchingUser ? (
-                          <TripPartyMemberBadge member={matchingUser} />
-                        ) : (
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="icon"
-                            onClick={() => addMemberToTrip(hit.uid, hit.email, hit.username)}
-                            disabled={isAddingMember === hit.uid}
-                          >
-                            {isAddingMember === hit.uid ? (
-                              <Loader2 className="size-4 animate-spin" />
-                            ) : (
-                              <Plus />
-                            )}
-                            <span className="sr-only">Add {hit.username} to trip</span>
-                          </Button>
-                        )}
-                      </div>
-                    )
-                  })}
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                Friends
+              </p>
+              <div className="max-h-[150px] space-y-1 overflow-y-auto">
+                {friendUids.map((fuid) => (
+                  <FriendInviteRow
+                    key={fuid}
+                    friendUid={fuid}
+                    tripMembers={tripMembers}
+                    isAddingMember={isAddingMember}
+                    onAdd={addMemberToTrip}
+                  />
+                ))}
               </div>
             </div>
-          </form>
-        </Form>
+          )}
+          <Form {...form}>
+            <form className="space-y-8">
+              <div className="space-y-2">
+                <FormField
+                  control={form.control}
+                  name="searchValue"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        {friendUids.length > 0 ? 'Search all users' : 'Add trip party member'}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="Search by username, email, or name..."
+                          {...field}
+                          onChange={(e) => {
+                            field.onChange(e)
+                            handleSearchValueChange(e)
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                      <FormDescription className="text-center">
+                        {isLoadingSearchResults && hits.length === 0 && (
+                          <span>
+                            <Loader2 className="mr-2 inline size-4 animate-spin" />
+                            Searching...
+                          </span>
+                        )}
+                        {!isLoadingSearchResults &&
+                          form.getValues('searchValue') !== '' &&
+                          form.getValues('searchValue').length >= 2 &&
+                          hits &&
+                          hits.length === 0 && (
+                            <span>
+                              No results found.{' '}
+                              <span
+                                className="text-primary cursor-pointer"
+                                onClick={() => form.reset()}
+                              >
+                                Clear search
+                              </span>
+                            </span>
+                          )}
+                      </FormDescription>
+                    </FormItem>
+                  )}
+                />
+                <div className="max-h-[200px] space-y-2 overflow-y-auto">
+                  {hits.length > 0 &&
+                    hits.map((hit) => {
+                      const matchingUser = tripMembers.find((member) => member.uid === hit.uid)
+                      const hitIsFriend = isFriend(hit.uid)
+                      return (
+                        <div key={hit.objectID}>
+                          <div className="text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors">
+                            <UserMediaObject user={hit} />
+                            {matchingUser ? (
+                              <TripPartyMemberBadge member={matchingUser} />
+                            ) : (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() =>
+                                  addMemberToTrip(hit.uid, hit.email, hit.username)
+                                }
+                                disabled={isAddingMember === hit.uid}
+                              >
+                                {isAddingMember === hit.uid ? (
+                                  <Loader2 className="size-4 animate-spin" />
+                                ) : (
+                                  <Plus />
+                                )}
+                                <span className="sr-only">Add {hit.username} to trip</span>
+                              </Button>
+                            )}
+                          </div>
+                          {!matchingUser && !hitIsFriend && (
+                            <label className="text-muted-foreground flex items-center gap-2 px-3 py-1 text-xs">
+                              <Checkbox
+                                checked={sendFriendRequestFor[hit.uid] ?? false}
+                                onCheckedChange={(checked) =>
+                                  setSendFriendRequestFor((prev) => ({
+                                    ...prev,
+                                    [hit.uid]: !!checked,
+                                  }))
+                                }
+                              />
+                              Also send {hit.username} a Friend Request
+                            </label>
+                          )}
+                        </div>
+                      )
+                    })}
+                </div>
+              </div>
+            </form>
+          </Form>
+        </div>
       </PopoverContent>
     </Popover>
   )

--- a/app/components/Trip/NewTrip/TagsStep.test.tsx
+++ b/app/components/Trip/NewTrip/TagsStep.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { useForm, FormProvider } from 'react-hook-form'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../contexts/auth/useAuth', () => ({
+  default: vi.fn(() => ({ user: { uid: 'u1' } })),
+  useAuth: vi.fn(() => ({ user: { uid: 'u1' } })),
+}))
+
+vi.mock('../../../services/gear', () => ({
+  useGearClosetQuery: vi.fn(() => ({ data: { customTags: [] } })),
+}))
+
+vi.mock('../../../services/users', () => ({
+  useUserByIdQuery: vi.fn(() => ({ data: undefined })),
+}))
+
+vi.mock('../../../services/trips', () => ({
+  useCreateTrip: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useGeneratePackingList: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}))
+
+import useAuth from '../../../contexts/auth/useAuth'
+import { useGearClosetQuery } from '../../../services/gear'
+import { useUserByIdQuery } from '../../../services/users'
+import TagsStep from './TagsStep'
+
+function Wrapper({ defaultTags = [] }: { defaultTags?: string[] }) {
+  const form = useForm({ defaultValues: { tags: defaultTags } })
+  return (
+    <MemoryRouter>
+      <FormProvider {...form}>
+        <TagsStep form={form as any} />
+      </FormProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('TagsStep', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({ user: { uid: 'u1' } } as any)
+    vi.mocked(useGearClosetQuery).mockReturnValue({ data: { customTags: [] } } as any)
+    vi.mocked(useUserByIdQuery).mockReturnValue({ data: undefined } as any)
+  })
+
+  describe('no tagCounts (new user)', () => {
+    it('shows full grouped list with no Frequently Used heading', () => {
+      render(<Wrapper />)
+      expect(screen.getByText('Activities')).toBeInTheDocument()
+      expect(screen.getByText('Accommodations')).toBeInTheDocument()
+      expect(screen.queryByText('Frequently Used')).not.toBeInTheDocument()
+    })
+
+    it('does not show See All toggle', () => {
+      render(<Wrapper />)
+      expect(screen.queryByText(/see all/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('has tagCounts (returning user)', () => {
+    beforeEach(() => {
+      vi.mocked(useUserByIdQuery).mockReturnValue({
+        data: { tagCounts: { hiking: 5, tent: 3, paddling: 1 } },
+      } as any)
+    })
+
+    it('renders Frequently Used heading', () => {
+      render(<Wrapper />)
+      expect(screen.getByText('Frequently Used')).toBeInTheDocument()
+    })
+
+    it('renders frequent tags unchecked by default', () => {
+      render(<Wrapper />)
+      const hikingCheckboxes = screen.getAllByRole('checkbox', { name: /hiking/i })
+      hikingCheckboxes.forEach((cb) => {
+        expect(cb).not.toBeChecked()
+      })
+    })
+
+    it('shows See All toggle', () => {
+      render(<Wrapper />)
+      expect(screen.getByText(/see all/i)).toBeInTheDocument()
+    })
+
+    it('selecting a tag in Frequently Used section checks it in both sections', async () => {
+      const user = userEvent.setup()
+      render(<Wrapper />)
+      const hikingCheckboxes = screen.getAllByRole('checkbox', { name: /hiking/i })
+      await user.click(hikingCheckboxes[0])
+      hikingCheckboxes.forEach((cb) => {
+        expect(cb).toBeChecked()
+      })
+    })
+
+    it('shows selected count in See All toggle when tags selected inside collapsed section', async () => {
+      const user = userEvent.setup()
+      render(<Wrapper />)
+
+      await user.click(screen.getByText(/see all/i))
+
+      const allActivitiesHeadings = screen.getAllByText('Activities')
+      const fullListActivities = allActivitiesHeadings[allActivitiesHeadings.length - 1]
+      const fullListSection = fullListActivities.closest('div')!
+      const fishingCheckbox = screen.getByRole('checkbox', { name: /fishing/i })
+      await user.click(fishingCheckbox)
+
+      await user.click(screen.getByText(/see less/i))
+
+      expect(screen.getByText(/see all.*1 selected/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('ghost custom tag filtering', () => {
+    it('excludes custom tag from Frequently Used when deleted from Gear Closet', () => {
+      vi.mocked(useUserByIdQuery).mockReturnValue({
+        data: { tagCounts: { hiking: 3, 'deleted-custom': 5 } },
+      } as any)
+      vi.mocked(useGearClosetQuery).mockReturnValue({
+        data: { customTags: [] },
+      } as any)
+
+      render(<Wrapper />)
+      expect(screen.getByText('Frequently Used')).toBeInTheDocument()
+      expect(screen.queryByText('deleted-custom')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/components/Trip/NewTrip/TagsStep.test.tsx
+++ b/app/components/Trip/NewTrip/TagsStep.test.tsx
@@ -100,9 +100,6 @@ describe('TagsStep', () => {
 
       await user.click(screen.getByText(/see all/i))
 
-      const allActivitiesHeadings = screen.getAllByText('Activities')
-      const fullListActivities = allActivitiesHeadings[allActivitiesHeadings.length - 1]
-      const fullListSection = fullListActivities.closest('div')!
       const fishingCheckbox = screen.getByRole('checkbox', { name: /fishing/i })
       await user.click(fishingCheckbox)
 

--- a/app/components/Trip/NewTrip/TagsStep.tsx
+++ b/app/components/Trip/NewTrip/TagsStep.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { z } from 'zod'
 
@@ -5,12 +6,15 @@ import { Checkbox } from '~/components/ui/checkbox'
 import { ScrollArea } from '~/components/ui/scroll-area'
 import useAuth from '~/contexts/auth/useAuth'
 import {
+  allGearListItems,
   gearListAccommodations,
   gearListActivities,
   gearListCampKitchen,
   gearListOtherConsiderations,
 } from '~/lib/gearListItemEnum'
+import { FREQUENT_TAGS_CAP,getFrequentTags } from '~/lib/getFrequentTags'
 import { useGearClosetQuery } from '~/services/gear'
+import { useUserByIdQuery } from '~/services/users'
 
 import AnimatedContainer from '../../AnimatedContainer'
 import { newTripFormSchema } from '.'
@@ -26,18 +30,80 @@ const tagGroups = [
   { label: 'Other Considerations', items: gearListOtherConsiderations },
 ]
 
+const predefinedLabelMap = new Map<string, string>(allGearListItems.map((i) => [i.name, i.label]))
+
 const TagsStep = ({ form }: TagsStepProps) => {
   const { user } = useAuth()
   const userId = user?.uid ?? ''
   const { data: closet } = useGearClosetQuery({ userId, queryOptions: { enabled: !!userId } })
+  const { data: userData } = useUserByIdQuery({ userId })
   const customTags = closet?.customTags ?? []
   const tags = form.watch('tags') ?? []
+  const [showAll, setShowAll] = useState(false)
+
+  const frequentTagKeys = getFrequentTags(userData?.tagCounts, customTags, FREQUENT_TAGS_CAP)
+  const hasFrequentTags = frequentTagKeys.length > 0
 
   const toggleTag = (key: string) => {
     const current = form.getValues('tags') ?? []
     const next = current.includes(key) ? current.filter((t) => t !== key) : [...current, key]
     form.setValue('tags', next, { shouldDirty: true })
   }
+
+  const allFullListKeys = new Set([
+    ...tagGroups.flatMap((g) => g.items.map((i) => i.name)),
+    ...customTags.map((ct) => ct.name),
+  ])
+  const selectedInFullList = tags.filter(
+    (t) => allFullListKeys.has(t) && !frequentTagKeys.includes(t)
+  ).length
+
+  const fullList = (
+    <div className="space-y-6">
+      {tagGroups.map((group) => (
+        <div key={group.label}>
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
+            {group.label}
+          </h4>
+          <div className="grid grid-cols-2 gap-2">
+            {group.items.map((item) => (
+              <label
+                key={item.name}
+                className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+              >
+                <Checkbox
+                  checked={tags.includes(item.name)}
+                  onCheckedChange={() => toggleTag(item.name)}
+                />
+                {item.label}
+              </label>
+            ))}
+          </div>
+        </div>
+      ))}
+      {customTags.length > 0 && (
+        <div>
+          <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
+            My Custom Tags
+          </h4>
+          <div className="grid grid-cols-2 gap-2">
+            {customTags.map((ct) => (
+              <label
+                key={ct.name}
+                className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+              >
+                <Checkbox
+                  checked={tags.includes(ct.name)}
+                  onCheckedChange={() => toggleTag(ct.name)}
+                />
+                {ct.name}
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
 
   return (
     <AnimatedContainer key="tags" animation="scaleAndFadeIn">
@@ -47,51 +113,47 @@ const TagsStep = ({ form }: TagsStepProps) => {
           Select tags to auto-generate a packing list from your gear closet.
         </p>
         <ScrollArea className="max-h-[350px] overflow-y-auto pr-3">
-          <div className="space-y-6">
-            {tagGroups.map((group) => (
-              <div key={group.label}>
-                <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
-                  {group.label}
-                </h4>
-                <div className="grid grid-cols-2 gap-2">
-                  {group.items.map((item) => (
-                    <label
-                      key={item.name}
-                      className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-                    >
-                      <Checkbox
-                        checked={tags.includes(item.name)}
-                        onCheckedChange={() => toggleTag(item.name)}
-                      />
-                      {item.label}
-                    </label>
-                  ))}
-                </div>
-              </div>
-            ))}
-            {customTags.length > 0 && (
+          {hasFrequentTags ? (
+            <div className="space-y-4">
               <div>
-                <h4 className="text-muted-foreground mb-2 text-xs font-medium tracking-wider uppercase">
-                  My Custom Tags
+                <h4 className="text-muted-foreground mb-1 text-xs font-medium tracking-wider uppercase">
+                  Frequently Used
                 </h4>
+                <p className="text-muted-foreground mb-2 text-xs">
+                  Based on your previous trips
+                </p>
                 <div className="grid grid-cols-2 gap-2">
-                  {customTags.map((ct) => (
-                    <label
-                      key={ct.name}
-                      className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-                    >
-                      <Checkbox
-                        checked={tags.includes(ct.name)}
-                        onCheckedChange={() => toggleTag(ct.name)}
-                      />
-
-                      {ct.name}
-                    </label>
-                  ))}
+                  {frequentTagKeys.map((key) => {
+                    const label = predefinedLabelMap.get(key) ?? key
+                    return (
+                      <label
+                        key={key}
+                        className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+                      >
+                        <Checkbox
+                          checked={tags.includes(key)}
+                          onCheckedChange={() => toggleTag(key)}
+                        />
+                        {label}
+                      </label>
+                    )
+                  })}
                 </div>
               </div>
-            )}
-          </div>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground text-sm font-medium"
+                onClick={() => setShowAll(!showAll)}
+              >
+                {showAll
+                  ? 'See Less'
+                  : `See All${selectedInFullList > 0 ? ` (${selectedInFullList} selected)` : ''}`}
+              </button>
+              {showAll && fullList}
+            </div>
+          ) : (
+            fullList
+          )}
         </ScrollArea>
       </div>
     </AnimatedContainer>

--- a/app/components/Trip/NewTrip/TagsStep.tsx
+++ b/app/components/Trip/NewTrip/TagsStep.tsx
@@ -12,7 +12,7 @@ import {
   gearListCampKitchen,
   gearListOtherConsiderations,
 } from '~/lib/gearListItemEnum'
-import { FREQUENT_TAGS_CAP,getFrequentTags } from '~/lib/getFrequentTags'
+import { FREQUENT_TAGS_CAP, getFrequentTags } from '~/lib/getFrequentTags'
 import { useGearClosetQuery } from '~/services/gear'
 import { useUserByIdQuery } from '~/services/users'
 
@@ -31,6 +31,23 @@ const tagGroups = [
 ]
 
 const predefinedLabelMap = new Map<string, string>(allGearListItems.map((i) => [i.name, i.label]))
+
+const TagCheckbox = ({
+  tagKey,
+  label,
+  checked,
+  onToggle,
+}: {
+  tagKey: string
+  label: string
+  checked: boolean
+  onToggle: (key: string) => void
+}) => (
+  <label className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm">
+    <Checkbox checked={checked} onCheckedChange={() => onToggle(tagKey)} />
+    {label}
+  </label>
+)
 
 const TagsStep = ({ form }: TagsStepProps) => {
   const { user } = useAuth()
@@ -67,16 +84,13 @@ const TagsStep = ({ form }: TagsStepProps) => {
           </h4>
           <div className="grid grid-cols-2 gap-2">
             {group.items.map((item) => (
-              <label
+              <TagCheckbox
                 key={item.name}
-                className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-              >
-                <Checkbox
-                  checked={tags.includes(item.name)}
-                  onCheckedChange={() => toggleTag(item.name)}
-                />
-                {item.label}
-              </label>
+                tagKey={item.name}
+                label={item.label}
+                checked={tags.includes(item.name)}
+                onToggle={toggleTag}
+              />
             ))}
           </div>
         </div>
@@ -88,16 +102,13 @@ const TagsStep = ({ form }: TagsStepProps) => {
           </h4>
           <div className="grid grid-cols-2 gap-2">
             {customTags.map((ct) => (
-              <label
+              <TagCheckbox
                 key={ct.name}
-                className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-              >
-                <Checkbox
-                  checked={tags.includes(ct.name)}
-                  onCheckedChange={() => toggleTag(ct.name)}
-                />
-                {ct.name}
-              </label>
+                tagKey={ct.name}
+                label={ct.name}
+                checked={tags.includes(ct.name)}
+                onToggle={toggleTag}
+              />
             ))}
           </div>
         </div>
@@ -123,21 +134,15 @@ const TagsStep = ({ form }: TagsStepProps) => {
                   Based on your previous trips
                 </p>
                 <div className="grid grid-cols-2 gap-2">
-                  {frequentTagKeys.map((key) => {
-                    const label = predefinedLabelMap.get(key) ?? key
-                    return (
-                      <label
-                        key={key}
-                        className="hover:bg-accent flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm"
-                      >
-                        <Checkbox
-                          checked={tags.includes(key)}
-                          onCheckedChange={() => toggleTag(key)}
-                        />
-                        {label}
-                      </label>
-                    )
-                  })}
+                  {frequentTagKeys.map((key) => (
+                    <TagCheckbox
+                      key={key}
+                      tagKey={key}
+                      label={predefinedLabelMap.get(key) ?? key}
+                      checked={tags.includes(key)}
+                      onToggle={toggleTag}
+                    />
+                  ))}
                 </div>
               </div>
               <button

--- a/app/components/Trip/NewTrip/TagsStep.tsx
+++ b/app/components/Trip/NewTrip/TagsStep.tsx
@@ -152,7 +152,9 @@ const TagsStep = ({ form }: TagsStepProps) => {
               >
                 {showAll
                   ? 'See Less'
-                  : `See All${selectedInFullList > 0 ? ` (${selectedInFullList} selected)` : ''}`}
+                  : selectedInFullList > 0
+                    ? `See All (${selectedInFullList} selected)`
+                    : 'See All'}
               </button>
               {showAll && fullList}
             </div>

--- a/app/components/Trip/NewTrip/index.tsx
+++ b/app/components/Trip/NewTrip/index.tsx
@@ -14,6 +14,7 @@ import useAuth from '~/contexts/auth/useAuth'
 import { activityKeyToLabel } from '~/lib/gearFilterUtils'
 import { allGearListItems } from '~/lib/gearListItemEnum'
 import { useCreateTrip, useGeneratePackingList } from '~/services/trips'
+import { useIncrementTagCounts } from '~/services/users'
 import type { ActivityTypes } from '~/types/GearItem'
 import { TripMemberStatus } from '~/types/TripMember'
 import type { User } from '~/types/User'
@@ -68,6 +69,7 @@ const NewTripForm = ({}: NewTripFormProps) => {
   const navigate = useNavigate()
   const { mutateAsync: createTrip } = useCreateTrip()
   const { mutateAsync: generatePackingList } = useGeneratePackingList()
+  const { mutate: incrementTagCounts } = useIncrementTagCounts(user?.uid ?? '')
 
   useEffect(() => {
     if (user) {
@@ -145,6 +147,10 @@ const NewTripForm = ({}: NewTripFormProps) => {
         },
         tripMembers: tripMembersMap,
       })
+
+      if (allTags.length > 0) {
+        incrementTagCounts({ tags: allTags })
+      }
 
       if (activityKeys.length > 0 || customTagValues.length > 0) {
         try {

--- a/app/lib/getFrequentTags.test.ts
+++ b/app/lib/getFrequentTags.test.ts
@@ -8,7 +8,7 @@ describe('getFrequentTags', () => {
   })
 
   it('returns empty array when tagCounts is undefined', () => {
-    expect(getFrequentTags(undefined as any, [], FREQUENT_TAGS_CAP)).toEqual([])
+    expect(getFrequentTags(undefined, [], FREQUENT_TAGS_CAP)).toEqual([])
   })
 
   it('returns a single tag with count 1', () => {

--- a/app/lib/getFrequentTags.test.ts
+++ b/app/lib/getFrequentTags.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFrequentTags, FREQUENT_TAGS_CAP } from './getFrequentTags'
+
+describe('getFrequentTags', () => {
+  it('returns empty array when tagCounts is empty', () => {
+    expect(getFrequentTags({}, [], FREQUENT_TAGS_CAP)).toEqual([])
+  })
+
+  it('returns empty array when tagCounts is undefined', () => {
+    expect(getFrequentTags(undefined as any, [], FREQUENT_TAGS_CAP)).toEqual([])
+  })
+
+  it('returns a single tag with count 1', () => {
+    expect(getFrequentTags({ hiking: 1 }, [], FREQUENT_TAGS_CAP)).toEqual(['hiking'])
+  })
+
+  it('sorts tags by count descending', () => {
+    const counts = { hiking: 3, paddling: 5, fishing: 1 }
+    const result = getFrequentTags(counts, [], FREQUENT_TAGS_CAP)
+    expect(result[0]).toBe('paddling')
+    expect(result[1]).toBe('hiking')
+    expect(result[2]).toBe('fishing')
+  })
+
+  it('caps results at the provided cap value', () => {
+    const counts = { hiking: 5, paddling: 4, fishing: 3, surfing: 2, tent: 1, carCamp: 1, hotel: 1 }
+    const result = getFrequentTags(counts, [], 3)
+    expect(result).toHaveLength(3)
+    expect(result).toEqual(['hiking', 'paddling', 'fishing'])
+  })
+
+  it('filters out custom tag keys not present in customTags', () => {
+    const counts = { hiking: 3, 'my-custom-tag': 5 }
+    const customTags = [{ name: 'other-tag' }]
+    const result = getFrequentTags(counts, customTags, FREQUENT_TAGS_CAP)
+    expect(result).toEqual(['hiking'])
+    expect(result).not.toContain('my-custom-tag')
+  })
+
+  it('does NOT filter out predefined tag keys even if absent from customTags', () => {
+    const counts = { hiking: 3, tent: 2 }
+    const result = getFrequentTags(counts, [], FREQUENT_TAGS_CAP)
+    expect(result).toContain('hiking')
+    expect(result).toContain('tent')
+  })
+
+  it('keeps custom tag keys that exist in customTags', () => {
+    const counts = { hiking: 2, 'my-tag': 5 }
+    const customTags = [{ name: 'my-tag' }]
+    const result = getFrequentTags(counts, customTags, FREQUENT_TAGS_CAP)
+    expect(result[0]).toBe('my-tag')
+    expect(result).toContain('hiking')
+  })
+
+  it('exports FREQUENT_TAGS_CAP as 6', () => {
+    expect(FREQUENT_TAGS_CAP).toBe(6)
+  })
+})

--- a/app/lib/getFrequentTags.test.ts
+++ b/app/lib/getFrequentTags.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { getFrequentTags, FREQUENT_TAGS_CAP } from './getFrequentTags'
+import { FREQUENT_TAGS_CAP, getFrequentTags } from './getFrequentTags'
 
 describe('getFrequentTags', () => {
   it('returns empty array when tagCounts is empty', () => {
@@ -11,46 +11,46 @@ describe('getFrequentTags', () => {
     expect(getFrequentTags(undefined, [], FREQUENT_TAGS_CAP)).toEqual([])
   })
 
-  it('returns a single tag with count 1', () => {
-    expect(getFrequentTags({ hiking: 1 }, [], FREQUENT_TAGS_CAP)).toEqual(['hiking'])
+  it('returns a single predefined tag with count 1', () => {
+    expect(getFrequentTags({ hiking: 1 }, [], FREQUENT_TAGS_CAP)).toEqual([
+      'hiking',
+    ])
   })
 
   it('sorts tags by count descending', () => {
-    const counts = { hiking: 3, paddling: 5, fishing: 1 }
-    const result = getFrequentTags(counts, [], FREQUENT_TAGS_CAP)
+    const tagCounts = { hiking: 3, paddling: 5, tent: 1 }
+    const result = getFrequentTags(tagCounts, [], FREQUENT_TAGS_CAP)
     expect(result[0]).toBe('paddling')
-    expect(result[1]).toBe('hiking')
-    expect(result[2]).toBe('fishing')
+    expect(result).toEqual(['paddling', 'hiking', 'tent'])
   })
 
   it('caps results at the provided cap value', () => {
-    const counts = { hiking: 5, paddling: 4, fishing: 3, surfing: 2, tent: 1, carCamp: 1, hotel: 1 }
-    const result = getFrequentTags(counts, [], 3)
+    const tagCounts = { hiking: 5, paddling: 4, tent: 3, surfing: 2, fishing: 1 }
+    const result = getFrequentTags(tagCounts, [], 3)
     expect(result).toHaveLength(3)
-    expect(result).toEqual(['hiking', 'paddling', 'fishing'])
+    expect(result).toEqual(['hiking', 'paddling', 'tent'])
   })
 
-  it('filters out custom tag keys not present in customTags', () => {
-    const counts = { hiking: 3, 'my-custom-tag': 5 }
-    const customTags = [{ name: 'other-tag' }]
-    const result = getFrequentTags(counts, customTags, FREQUENT_TAGS_CAP)
+  it('filters out a custom tag key absent from customTags', () => {
+    const tagCounts = { hiking: 3, 'my-deleted-tag': 5 }
+    const result = getFrequentTags(tagCounts, [], FREQUENT_TAGS_CAP)
     expect(result).toEqual(['hiking'])
-    expect(result).not.toContain('my-custom-tag')
+    expect(result).not.toContain('my-deleted-tag')
   })
 
-  it('does NOT filter out predefined tag keys even if absent from customTags', () => {
-    const counts = { hiking: 3, tent: 2 }
-    const result = getFrequentTags(counts, [], FREQUENT_TAGS_CAP)
+  it('keeps a custom tag key present in customTags', () => {
+    const tagCounts = { hiking: 1, 'my-custom-tag': 5 }
+    const customTags = [{ name: 'my-custom-tag' }]
+    const result = getFrequentTags(tagCounts, customTags, FREQUENT_TAGS_CAP)
+    expect(result).toEqual(['my-custom-tag', 'hiking'])
+  })
+
+  it('never filters out a predefined tag regardless of customTags', () => {
+    const tagCounts = { hiking: 3, tent: 2, carCamping: 1 }
+    const result = getFrequentTags(tagCounts, [], FREQUENT_TAGS_CAP)
     expect(result).toContain('hiking')
     expect(result).toContain('tent')
-  })
-
-  it('keeps custom tag keys that exist in customTags', () => {
-    const counts = { hiking: 2, 'my-tag': 5 }
-    const customTags = [{ name: 'my-tag' }]
-    const result = getFrequentTags(counts, customTags, FREQUENT_TAGS_CAP)
-    expect(result[0]).toBe('my-tag')
-    expect(result).toContain('hiking')
+    expect(result).toContain('carCamping')
   })
 
   it('exports FREQUENT_TAGS_CAP as 6', () => {

--- a/app/lib/getFrequentTags.ts
+++ b/app/lib/getFrequentTags.ts
@@ -1,0 +1,21 @@
+import { allGearListItems } from './gearListItemEnum'
+
+export const FREQUENT_TAGS_CAP = 6
+
+const predefinedKeySet = new Set<string>(allGearListItems.map((i) => i.name))
+
+export function getFrequentTags(
+  tagCounts: Record<string, number> | undefined,
+  customTags: { name: string }[],
+  cap: number
+): string[] {
+  if (!tagCounts || Object.keys(tagCounts).length === 0) return []
+
+  const customTagNames = new Set(customTags.map((t) => t.name))
+
+  return Object.entries(tagCounts)
+    .filter(([key]) => predefinedKeySet.has(key) || customTagNames.has(key))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, cap)
+    .map(([key]) => key)
+}

--- a/app/lib/getFrequentTags.ts
+++ b/app/lib/getFrequentTags.ts
@@ -1,15 +1,15 @@
-import { allGearListItems } from './gearListItemEnum'
+import { gearListKeys } from './gearListItemEnum'
 
 export const FREQUENT_TAGS_CAP = 6
 
-const predefinedKeySet = new Set<string>(allGearListItems.map((i) => i.name))
+const predefinedKeySet: Set<string> = new Set(gearListKeys)
 
 export function getFrequentTags(
   tagCounts: Record<string, number> | undefined,
   customTags: { name: string }[],
-  cap: number
+  cap: number,
 ): string[] {
-  if (!tagCounts || Object.keys(tagCounts).length === 0) return []
+  if (!tagCounts) return []
 
   const customTagNames = new Set(customTags.map((t) => t.name))
 

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../lib/useIsAnonymous', () => ({
+  useIsAnonymous: vi.fn(),
+}))
+
+vi.mock('../contexts/auth/useAuth', () => ({
+  useAuth: vi.fn(() => ({
+    user: { uid: 'u1', username: 'testuser', email: 'test@test.com' },
+  })),
+}))
+
+vi.mock('../services/friends', () => ({
+  useFriendsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  usePendingFriendRequestsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useSendFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useAcceptFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useDeclineFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  useUnfriend: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+}))
+
+vi.mock('../services/users', () => ({
+  useUserByIdQuery: vi.fn(() => ({ data: null })),
+}))
+
+import { useIsAnonymous } from '../lib/useIsAnonymous'
+import { useFriendsQuery, usePendingFriendRequestsQuery } from '../services/friends'
+import Friends from './friends'
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <Friends />
+    </MemoryRouter>
+  )
+}
+
+describe('Friends page', () => {
+  it('shows Account Gate for anonymous users', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(true)
+    renderComponent()
+    expect(screen.getByText('Create an account to connect with friends')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /create account/i })).toHaveAttribute('href', '/signup')
+  })
+
+  it('shows empty friends state for registered users with no friends', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    renderComponent()
+    expect(screen.getByText('No friends yet')).toBeInTheDocument()
+    expect(screen.getByText('Find friends')).toBeInTheDocument()
+  })
+
+  it('hides friend requests section when there are no pending requests', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as any)
+    renderComponent()
+    expect(screen.queryByText('Friend Requests')).not.toBeInTheDocument()
+  })
+
+  it('shows friend requests section when requests exist', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'req_uid1',
+          uids: ['sender', 'u1'],
+          requesterUid: 'sender',
+          status: 'pending',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    renderComponent()
+    expect(screen.getByText('Friend Requests')).toBeInTheDocument()
+  })
+
+  it('shows friends count when friends exist', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'u1_u2',
+          uids: ['u1', 'u2'],
+          requesterUid: 'u1',
+          status: 'accepted',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    renderComponent()
+    expect(screen.getByText('(1)')).toBeInTheDocument()
+  })
+
+  it('shows loading state', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({ data: [], isLoading: true } as any)
+    renderComponent()
+    expect(screen.queryByText('No friends yet')).not.toBeInTheDocument()
+  })
+})

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,7 +1,37 @@
+import type { SearchResponse } from 'algoliasearch'
+import { Check, Loader2, Search, UserMinus, UserPlus, UsersIcon, X } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+
 import PageContent from '~/components/PageContent'
 import PageHeader from '~/components/PageHeader'
+import { Badge } from '~/components/ui/badge'
+import { Button } from '~/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog'
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '~/components/ui/empty'
+import { Input } from '~/components/ui/input'
 import { UpgradeAccountGate } from '~/components/UpgradeAccountGate'
+import UserMediaObject from '~/components/UserMediaObject'
+import { useAuth } from '~/contexts/auth/useAuth'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
+import {
+  useAcceptFriendRequest,
+  useDeclineFriendRequest,
+  useFriendsQuery,
+  usePendingFriendRequestsQuery,
+  useSendFriendRequest,
+  useUnfriend,
+} from '~/services/friends'
+import { useUserByIdQuery } from '~/services/users'
+import type { Friendship } from '~/types/Friendship'
+import type { User } from '~/types/User'
 
 import type { Route } from './+types/home'
 
@@ -9,8 +39,248 @@ export function meta({}: Route.MetaArgs) {
   return [{ title: 'Friends | Packup' }]
 }
 
+function FriendRequestCard({
+  friendship,
+  currentUid,
+}: {
+  friendship: Friendship
+  currentUid: string
+}) {
+  const { data: requester } = useUserByIdQuery({ userId: friendship.requesterUid })
+  const { mutateAsync: accept, isPending: isAccepting } = useAcceptFriendRequest(currentUid)
+  const { mutateAsync: decline, isPending: isDeclining } = useDeclineFriendRequest(currentUid)
+
+  if (!requester) return null
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+      <UserMediaObject user={requester} />
+      <div className="flex gap-2">
+        <Button
+          variant="accent"
+          size="sm"
+          onClick={() => accept({ friendshipId: friendship.id })}
+          disabled={isAccepting || isDeclining}
+        >
+          {isAccepting ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
+          Accept
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => decline({ friendshipId: friendship.id })}
+          disabled={isAccepting || isDeclining}
+        >
+          {isDeclining ? <Loader2 className="size-4 animate-spin" /> : <X className="size-4" />}
+          Decline
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function FriendCard({ friendship, currentUid }: { friendship: Friendship; currentUid: string }) {
+  const friendUid = friendship.uids.find((uid) => uid !== currentUid) ?? ''
+  const { data: friend } = useUserByIdQuery({ userId: friendUid })
+  const { mutateAsync: removeFriend, isPending } = useUnfriend(currentUid)
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  if (!friend) return null
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
+      <UserMediaObject user={friend} />
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm">
+            <UserMinus className="size-4" />
+            Unfriend
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Unfriend {friend.displayName}?</DialogTitle>
+            <DialogDescription>
+              This will remove {friend.displayName} from your friends list. They will not be
+              notified.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={isPending}
+              onClick={async () => {
+                await removeFriend({ friendshipId: friendship.id })
+                setConfirmOpen(false)
+              }}
+            >
+              {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+              Unfriend
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+function FindFriends({ currentUid, friendships }: { currentUid: string; friendships: Friendship[] }) {
+  const [searchValue, setSearchValue] = useState('')
+  const [hits, setHits] = useState<SearchResponse<User>['hits']>([])
+  const [isSearching, setIsSearching] = useState(false)
+  const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(null)
+  const [isHydrated, setIsHydrated] = useState(false)
+  const [algoliaService, setAlgoliaService] = useState<typeof import('~/services/algoliaSearch').algoliaSearch | null>(null)
+  const { mutateAsync: sendRequest } = useSendFriendRequest()
+  const [sendingTo, setSendingTo] = useState<string | null>(null)
+
+  useEffect(() => {
+    setIsHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    const loadAlgolia = async () => {
+      try {
+        const { algoliaSearch } = await import('~/services/algoliaSearch')
+        setAlgoliaService(algoliaSearch)
+      } catch (error) {
+        console.error('Failed to load Algolia:', error)
+      }
+    }
+    if (isHydrated) loadAlgolia()
+  }, [isHydrated])
+
+  useEffect(() => {
+    return () => {
+      if (searchTimeout) clearTimeout(searchTimeout)
+    }
+  }, [searchTimeout])
+
+  const doSearch = useCallback(
+    async (value: string) => {
+      if (!algoliaService || value.length < 2) {
+        setHits([])
+        setIsSearching(false)
+        return
+      }
+      try {
+        const response = await algoliaService.search<User>([
+          { indexName: 'Users', query: value },
+        ])
+        const result = response.results[0]
+        if ('hits' in result) {
+          setHits(result.hits.filter((h) => h.uid !== currentUid))
+        }
+      } catch (error) {
+        console.error('Search error:', error)
+      } finally {
+        setIsSearching(false)
+      }
+    },
+    [algoliaService, currentUid]
+  )
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.toLowerCase()
+    setSearchValue(value)
+    if (searchTimeout) clearTimeout(searchTimeout)
+    if (value.length < 2) {
+      setIsSearching(false)
+      setHits([])
+    } else {
+      setIsSearching(true)
+    }
+    const timeout = setTimeout(() => doSearch(value), 200)
+    setSearchTimeout(timeout)
+  }
+
+  const getConnectionStatus = (hitUid: string): 'friend' | 'pending' | 'none' => {
+    const friendship = friendships.find(
+      (f) => f.uids.includes(hitUid)
+    )
+    if (!friendship) return 'none'
+    if (friendship.status === 'accepted') return 'friend'
+    if (friendship.status === 'pending') return 'pending'
+    return 'none'
+  }
+
+  const handleSendRequest = async (recipientUid: string) => {
+    setSendingTo(recipientUid)
+    try {
+      await sendRequest({ senderUid: currentUid, recipientUid })
+    } finally {
+      setSendingTo(null)
+    }
+  }
+
+  return (
+    <section>
+      <h2 className="mb-3 text-lg font-bold">Find friends</h2>
+      <div className="relative mb-4">
+        <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          placeholder="Search by username, email, or name..."
+          value={searchValue}
+          onChange={handleChange}
+          className="pl-9"
+        />
+      </div>
+      {isSearching && hits.length === 0 && (
+        <p className="text-muted-foreground flex items-center gap-2 text-sm">
+          <Loader2 className="size-4 animate-spin" />
+          Searching...
+        </p>
+      )}
+      {!isSearching && searchValue.length >= 2 && hits.length === 0 && (
+        <p className="text-muted-foreground text-sm">No results found.</p>
+      )}
+      <div className="space-y-2">
+        {hits.map((hit) => {
+          const status = getConnectionStatus(hit.uid)
+          return (
+            <div
+              key={hit.objectID}
+              className="flex items-center justify-between gap-3 rounded-lg border p-3"
+            >
+              <UserMediaObject user={hit} />
+              {status === 'friend' && <Badge variant="success">Friends</Badge>}
+              {status === 'pending' && <Badge variant="secondary">Pending</Badge>}
+              {status === 'none' && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleSendRequest(hit.uid)}
+                  disabled={sendingTo === hit.uid}
+                >
+                  {sendingTo === hit.uid ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <UserPlus className="size-4" />
+                  )}
+                  Send Friend Request
+                </Button>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
 export default function Friends() {
   const isAnonymous = useIsAnonymous()
+  const { user } = useAuth()
+  const uid = user?.uid ?? ''
+
+  const { data: friends = [], isLoading: friendsLoading } = useFriendsQuery(uid)
+  const { data: pendingRequests = [], isLoading: requestsLoading } =
+    usePendingFriendRequestsQuery(uid)
+
+  const allFriendships = [...friends, ...pendingRequests]
 
   return (
     <>
@@ -21,7 +291,64 @@ export default function Friends() {
             <div />
           </UpgradeAccountGate>
         ) : (
-          <p>Friends will go here</p>
+          <div className="mx-auto max-w-2xl space-y-8">
+            {requestsLoading || friendsLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="text-muted-foreground size-6 animate-spin" />
+              </div>
+            ) : (
+              <>
+                {pendingRequests.length > 0 && (
+                  <section>
+                    <h2 className="mb-3 text-lg font-bold">
+                      Friend Requests{' '}
+                      <Badge variant="default" className="ml-1">
+                        {pendingRequests.length}
+                      </Badge>
+                    </h2>
+                    <div className="space-y-2">
+                      {pendingRequests.map((req) => (
+                        <FriendRequestCard key={req.id} friendship={req} currentUid={uid} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                <section>
+                  <h2 className="mb-3 text-lg font-bold">
+                    Friends{' '}
+                    {friends.length > 0 && (
+                      <span className="text-muted-foreground text-sm font-normal">
+                        ({friends.length})
+                      </span>
+                    )}
+                  </h2>
+                  {friends.length === 0 ? (
+                    <Empty>
+                      <EmptyHeader>
+                        <EmptyMedia variant="icon">
+                          <UsersIcon />
+                        </EmptyMedia>
+                        <EmptyTitle>No friends yet</EmptyTitle>
+                        <EmptyDescription>
+                          Use the search below to find people you know and send them a friend
+                          request.
+                        </EmptyDescription>
+                      </EmptyHeader>
+                    </Empty>
+                  ) : (
+                    <div className="space-y-2">
+                      {friends.map((f) => (
+                        <FriendCard key={f.id} friendship={f} currentUid={uid} />
+                      ))}
+                    </div>
+                  )}
+                </section>
+
+                <FindFriends currentUid={uid} friendships={allFriendships} />
+              </>
+            )}
+          </div>
         )}
       </PageContent>
     </>

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -132,14 +132,9 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
   const [hits, setHits] = useState<SearchResponse<User>['hits']>([])
   const [isSearching, setIsSearching] = useState(false)
   const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(null)
-  const [isHydrated, setIsHydrated] = useState(false)
   const [algoliaService, setAlgoliaService] = useState<typeof import('~/services/algoliaSearch').algoliaSearch | null>(null)
   const { mutateAsync: sendRequest } = useSendFriendRequest()
   const [sendingTo, setSendingTo] = useState<string | null>(null)
-
-  useEffect(() => {
-    setIsHydrated(true)
-  }, [])
 
   useEffect(() => {
     const loadAlgolia = async () => {
@@ -150,8 +145,8 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
         console.error('Failed to load Algolia:', error)
       }
     }
-    if (isHydrated) loadAlgolia()
-  }, [isHydrated])
+    loadAlgolia()
+  }, [])
 
   useEffect(() => {
     return () => {

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,4 +1,5 @@
 import { EmergencyContacts } from '~/components/EmergencyContacts'
+import { FriendRequestEmailToggle } from '~/components/FriendRequestEmailToggle'
 import PageContent from '~/components/PageContent'
 import PageHeader from '~/components/PageHeader'
 import { SafetyItineraryToggle } from '~/components/SafetyItineraryToggle'
@@ -50,6 +51,12 @@ export default function Settings() {
               description="Receive an email the day before your trip with details, members, and emergency contacts. You can disable this on a per-trip basis in Trip Settings as well."
             >
               <SafetyItineraryToggle />
+            </PreferenceRow>
+            <PreferenceRow
+              label="Friend Request Email"
+              description="Receive an email when someone sends you a friend request."
+            >
+              <FriendRequestEmailToggle />
             </PreferenceRow>
           </div>
         </section>

--- a/app/services/friends.test.ts
+++ b/app/services/friends.test.ts
@@ -1,0 +1,218 @@
+import { Timestamp } from 'firebase/firestore'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const mockGetDoc = vi.fn()
+const mockSetDoc = vi.fn()
+const mockDeleteDoc = vi.fn()
+const mockUpdateDoc = vi.fn()
+const mockDoc = vi.fn()
+const mockQuery = vi.fn()
+const mockCollection = vi.fn()
+const mockWhere = vi.fn()
+const mockGetDocs = vi.fn()
+
+vi.mock('firebase/firestore', async () => {
+  const actual = await vi.importActual<typeof import('firebase/firestore')>('firebase/firestore')
+  return {
+    ...actual,
+    getDoc: (...args: any[]) => mockGetDoc(...args),
+    setDoc: (...args: any[]) => mockSetDoc(...args),
+    deleteDoc: (...args: any[]) => mockDeleteDoc(...args),
+    updateDoc: (...args: any[]) => mockUpdateDoc(...args),
+    doc: (...args: any[]) => mockDoc(...args),
+    query: (...args: any[]) => mockQuery(...args),
+    collection: (...args: any[]) => mockCollection(...args),
+    where: (...args: any[]) => mockWhere(...args),
+    getDocs: (...args: any[]) => mockGetDocs(...args),
+  }
+})
+
+vi.mock('../firebase/config', () => ({
+  firestoreDb: {},
+}))
+
+import { buildFriendshipId } from '../types/Friendship'
+import {
+  fetchFriendships,
+  fetchPendingRequests,
+  sendFriendRequest,
+  acceptFriendRequest,
+  declineFriendRequest,
+  unfriend,
+} from './friends'
+
+describe('buildFriendshipId', () => {
+  it('sorts UIDs alphabetically and joins with underscore', () => {
+    expect(buildFriendshipId('zzzUser', 'aaaUser')).toBe('aaaUser_zzzUser')
+  })
+
+  it('produces the same ID regardless of order', () => {
+    expect(buildFriendshipId('uid1', 'uid2')).toBe(buildFriendshipId('uid2', 'uid1'))
+  })
+})
+
+describe('friends service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDoc.mockReturnValue('mock-doc-ref')
+    mockCollection.mockReturnValue('mock-collection-ref')
+    mockQuery.mockReturnValue('mock-query-ref')
+    mockWhere.mockReturnValue('mock-where-constraint')
+  })
+
+  describe('sendFriendRequest', () => {
+    it('creates a pending friendship document with correct fields', async () => {
+      mockGetDoc.mockResolvedValue({ exists: () => false })
+      mockSetDoc.mockResolvedValue(undefined)
+
+      await sendFriendRequest('senderUid', 'recipientUid')
+
+      expect(mockSetDoc).toHaveBeenCalledWith(
+        'mock-doc-ref',
+        expect.objectContaining({
+          uids: expect.arrayContaining(['senderUid', 'recipientUid']),
+          requesterUid: 'senderUid',
+          status: 'pending',
+        })
+      )
+    })
+
+    it('rejects if a request was declined within 30 days', async () => {
+      const recentDecline = Timestamp.fromDate(new Date())
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          status: 'declined',
+          declinedAt: recentDecline,
+        }),
+      })
+
+      await expect(sendFriendRequest('senderUid', 'recipientUid')).rejects.toThrow(
+        '30-day cooldown'
+      )
+      expect(mockSetDoc).not.toHaveBeenCalled()
+    })
+
+    it('allows re-send after 30 days of decline', async () => {
+      const oldDecline = Timestamp.fromDate(new Date(Date.now() - 31 * 24 * 60 * 60 * 1000))
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({
+          status: 'declined',
+          declinedAt: oldDecline,
+        }),
+      })
+      mockSetDoc.mockResolvedValue(undefined)
+
+      await sendFriendRequest('senderUid', 'recipientUid')
+      expect(mockSetDoc).toHaveBeenCalled()
+    })
+
+    it('rejects if friendship already exists and is pending', async () => {
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({ status: 'pending' }),
+      })
+
+      await expect(sendFriendRequest('senderUid', 'recipientUid')).rejects.toThrow(
+        'already pending'
+      )
+    })
+
+    it('rejects if friendship already exists and is accepted', async () => {
+      mockGetDoc.mockResolvedValue({
+        exists: () => true,
+        data: () => ({ status: 'accepted' }),
+      })
+
+      await expect(sendFriendRequest('senderUid', 'recipientUid')).rejects.toThrow(
+        'already friends'
+      )
+    })
+  })
+
+  describe('acceptFriendRequest', () => {
+    it('updates status to accepted and sets respondedAt', async () => {
+      mockUpdateDoc.mockResolvedValue(undefined)
+
+      await acceptFriendRequest('uid1_uid2')
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        'mock-doc-ref',
+        expect.objectContaining({
+          status: 'accepted',
+          respondedAt: expect.any(Timestamp),
+        })
+      )
+    })
+  })
+
+  describe('declineFriendRequest', () => {
+    it('updates status to declined and sets declinedAt', async () => {
+      mockUpdateDoc.mockResolvedValue(undefined)
+
+      await declineFriendRequest('uid1_uid2')
+
+      expect(mockUpdateDoc).toHaveBeenCalledWith(
+        'mock-doc-ref',
+        expect.objectContaining({
+          status: 'declined',
+          declinedAt: expect.any(Timestamp),
+          respondedAt: expect.any(Timestamp),
+        })
+      )
+    })
+  })
+
+  describe('unfriend', () => {
+    it('deletes the friendship document', async () => {
+      mockDeleteDoc.mockResolvedValue(undefined)
+
+      await unfriend('uid1_uid2')
+
+      expect(mockDeleteDoc).toHaveBeenCalledWith('mock-doc-ref')
+    })
+  })
+
+  describe('fetchFriendships', () => {
+    it('returns accepted friendships for a user', async () => {
+      const friendship = {
+        id: 'uid1_uid2',
+        uids: ['uid1', 'uid2'],
+        requesterUid: 'uid1',
+        status: 'accepted',
+        requestedAt: Timestamp.fromDate(new Date()),
+      }
+      mockGetDocs.mockResolvedValue({
+        docs: [{ id: 'uid1_uid2', data: () => friendship }],
+      })
+
+      const result = await fetchFriendships('uid1')
+
+      expect(mockWhere).toHaveBeenCalledWith('uids', 'array-contains', 'uid1')
+      expect(mockWhere).toHaveBeenCalledWith('status', '==', 'accepted')
+      expect(result).toHaveLength(1)
+      expect(result[0].status).toBe('accepted')
+    })
+  })
+
+  describe('fetchPendingRequests', () => {
+    it('returns pending requests where user is the recipient', async () => {
+      const request = {
+        id: 'sender_uid1',
+        uids: ['sender', 'uid1'],
+        requesterUid: 'sender',
+        status: 'pending',
+        requestedAt: Timestamp.fromDate(new Date()),
+      }
+      mockGetDocs.mockResolvedValue({
+        docs: [{ id: 'sender_uid1', data: () => request }],
+      })
+
+      const result = await fetchPendingRequests('uid1')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].requesterUid).not.toBe('uid1')
+    })
+  })
+})

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -100,8 +100,6 @@ export async function fetchPendingRequests(uid: string): Promise<Friendship[]> {
     .filter((f) => f.requesterUid !== uid)
 }
 
-// React Query hooks
-
 export function useFriendsQuery(uid: string) {
   return useQuery<Friendship[], Error>({
     queryKey: friendKeys.byUid(uid),
@@ -126,15 +124,13 @@ export function useSendFriendRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       senderUid,
       recipientUid,
     }: {
       senderUid: string
       recipientUid: string
-    }) => {
-      await sendFriendRequest(senderUid, recipientUid)
-    },
+    }) => sendFriendRequest(senderUid, recipientUid),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: friendKeys.byUid(variables.senderUid) })
       queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(variables.senderUid) })
@@ -150,9 +146,8 @@ export function useAcceptFriendRequest(currentUid: string) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
-      await acceptFriendRequest(friendshipId)
-    },
+    mutationFn: ({ friendshipId }: { friendshipId: string }) =>
+      acceptFriendRequest(friendshipId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
       queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(currentUid) })
@@ -168,9 +163,8 @@ export function useDeclineFriendRequest(currentUid: string) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
-      await declineFriendRequest(friendshipId)
-    },
+    mutationFn: ({ friendshipId }: { friendshipId: string }) =>
+      declineFriendRequest(friendshipId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(currentUid) })
     },
@@ -181,9 +175,7 @@ export function useUnfriend(currentUid: string) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
-      await unfriend(friendshipId)
-    },
+    mutationFn: ({ friendshipId }: { friendshipId: string }) => unfriend(friendshipId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
       toast.success('Friend removed')

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -1,0 +1,195 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  setDoc,
+  Timestamp,
+  updateDoc,
+  where,
+} from 'firebase/firestore'
+import { toast } from 'sonner'
+
+import { firestoreDb } from '~/firebase/config'
+import { buildFriendshipId, type Friendship } from '~/types/Friendship'
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+
+const friendsRootKey = ['friendships'] as const
+
+export const friendKeys = {
+  root: friendsRootKey,
+  byUid: (uid: string) => [...friendsRootKey, 'byUid', uid] as const,
+  requestsForUid: (uid: string) => [...friendsRootKey, 'requests', uid] as const,
+}
+
+export async function sendFriendRequest(senderUid: string, recipientUid: string): Promise<void> {
+  const friendshipId = buildFriendshipId(senderUid, recipientUid)
+  const docRef = doc(firestoreDb, 'friendships', friendshipId)
+  const existing = await getDoc(docRef)
+
+  if (existing.exists()) {
+    const data = existing.data()
+    if (data.status === 'accepted') {
+      throw new Error('You are already friends with this user')
+    }
+    if (data.status === 'pending') {
+      throw new Error('A friend request is already pending')
+    }
+    if (data.status === 'declined' && data.declinedAt) {
+      const declinedMs = data.declinedAt.toMillis()
+      if (Date.now() - declinedMs < THIRTY_DAYS_MS) {
+        throw new Error('Cannot re-send: 30-day cooldown has not elapsed')
+      }
+    }
+  }
+
+  await setDoc(docRef, {
+    uids: [senderUid, recipientUid],
+    requesterUid: senderUid,
+    status: 'pending',
+    requestedAt: Timestamp.now(),
+  })
+}
+
+export async function acceptFriendRequest(friendshipId: string): Promise<void> {
+  const docRef = doc(firestoreDb, 'friendships', friendshipId)
+  await updateDoc(docRef, {
+    status: 'accepted',
+    respondedAt: Timestamp.now(),
+  })
+}
+
+export async function declineFriendRequest(friendshipId: string): Promise<void> {
+  const docRef = doc(firestoreDb, 'friendships', friendshipId)
+  const now = Timestamp.now()
+  await updateDoc(docRef, {
+    status: 'declined',
+    declinedAt: now,
+    respondedAt: now,
+  })
+}
+
+export async function unfriend(friendshipId: string): Promise<void> {
+  const docRef = doc(firestoreDb, 'friendships', friendshipId)
+  await deleteDoc(docRef)
+}
+
+export async function fetchFriendships(uid: string): Promise<Friendship[]> {
+  const q = query(
+    collection(firestoreDb, 'friendships'),
+    where('uids', 'array-contains', uid),
+    where('status', '==', 'accepted')
+  )
+  const snap = await getDocs(q)
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Friendship)
+}
+
+export async function fetchPendingRequests(uid: string): Promise<Friendship[]> {
+  const q = query(
+    collection(firestoreDb, 'friendships'),
+    where('uids', 'array-contains', uid),
+    where('status', '==', 'pending')
+  )
+  const snap = await getDocs(q)
+  return snap.docs
+    .map((d) => ({ id: d.id, ...d.data() }) as Friendship)
+    .filter((f) => f.requesterUid !== uid)
+}
+
+// React Query hooks
+
+export function useFriendsQuery(uid: string) {
+  return useQuery<Friendship[], Error>({
+    queryKey: friendKeys.byUid(uid),
+    queryFn: () => fetchFriendships(uid),
+    enabled: !!uid,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  })
+}
+
+export function usePendingFriendRequestsQuery(uid: string) {
+  return useQuery<Friendship[], Error>({
+    queryKey: friendKeys.requestsForUid(uid),
+    queryFn: () => fetchPendingRequests(uid),
+    enabled: !!uid,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  })
+}
+
+export function useSendFriendRequest() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({
+      senderUid,
+      recipientUid,
+    }: {
+      senderUid: string
+      recipientUid: string
+    }) => {
+      await sendFriendRequest(senderUid, recipientUid)
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: friendKeys.byUid(variables.senderUid) })
+      queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(variables.senderUid) })
+      toast.success('Friend request sent')
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+}
+
+export function useAcceptFriendRequest(currentUid: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
+      await acceptFriendRequest(friendshipId)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
+      queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(currentUid) })
+      toast.success('Friend request accepted')
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+}
+
+export function useDeclineFriendRequest(currentUid: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
+      await declineFriendRequest(friendshipId)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: friendKeys.requestsForUid(currentUid) })
+    },
+  })
+}
+
+export function useUnfriend(currentUid: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ friendshipId }: { friendshipId: string }) => {
+      await unfriend(friendshipId)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
+      toast.success('Friend removed')
+    },
+    onError: (err: Error) => {
+      toast.error(err.message)
+    },
+  })
+}

--- a/app/services/users.test.ts
+++ b/app/services/users.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockUpdateDoc = vi.fn()
+const mockIncrement = vi.fn((n: number) => ({ __increment: n }))
+const mockDoc = vi.fn(() => 'mock-doc-ref')
+
+vi.mock('firebase/firestore', () => ({
+  doc: (...args: any[]) => mockDoc(...args),
+  updateDoc: (...args: any[]) => mockUpdateDoc(...args),
+  increment: (n: number) => mockIncrement(n),
+  getDoc: vi.fn(),
+  setDoc: vi.fn(),
+  Timestamp: { fromDate: vi.fn(() => 'mock-ts') },
+}))
+
+vi.mock('../firebase/config', () => ({
+  firestoreDb: 'mock-db',
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: vi.fn((opts: any) => ({
+    mutateAsync: opts.mutationFn,
+    mutate: opts.mutationFn,
+  })),
+  useQuery: vi.fn(),
+  useQueryClient: vi.fn(() => ({
+    cancelQueries: vi.fn(),
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+  })),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+import { useIncrementTagCounts } from './users'
+
+describe('useIncrementTagCounts', () => {
+  beforeEach(() => {
+    mockUpdateDoc.mockReset()
+    mockIncrement.mockReset().mockImplementation((n: number) => ({ __increment: n }))
+    mockDoc.mockReset().mockReturnValue('mock-doc-ref')
+  })
+
+  it('issues a single updateDoc with one increment(1) per tag key', async () => {
+    const { mutateAsync } = useIncrementTagCounts('user-1')
+    await mutateAsync({ tags: ['hiking', 'tent'] })
+
+    expect(mockUpdateDoc).toHaveBeenCalledTimes(1)
+    expect(mockUpdateDoc).toHaveBeenCalledWith('mock-doc-ref', {
+      'tagCounts.hiking': { __increment: 1 },
+      'tagCounts.tent': { __increment: 1 },
+    })
+  })
+
+  it('does not call updateDoc when tags array is empty', async () => {
+    const { mutateAsync } = useIncrementTagCounts('user-1')
+    await mutateAsync({ tags: [] })
+
+    expect(mockUpdateDoc).not.toHaveBeenCalled()
+  })
+})

--- a/app/services/users.ts
+++ b/app/services/users.ts
@@ -1,5 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { doc, getDoc, type QueryConstraint, setDoc, Timestamp, updateDoc } from 'firebase/firestore'
+import {
+  doc,
+  getDoc,
+  increment,
+  type QueryConstraint,
+  setDoc,
+  Timestamp,
+  updateDoc,
+} from 'firebase/firestore'
 import { toast } from 'sonner'
 
 import { firestoreDb } from '~/firebase/config'
@@ -80,6 +88,20 @@ export function useUpdateUser(userId: string) {
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: userQueryKey })
+    },
+  })
+}
+
+export function useIncrementTagCounts(userId: string) {
+  return useMutation({
+    mutationFn: async ({ tags }: { tags: string[] }) => {
+      if (tags.length === 0) return
+      const docRef = doc(firestoreDb, 'users', userId)
+      const payload: Record<string, ReturnType<typeof increment>> = {}
+      for (const tag of tags) {
+        payload[`tagCounts.${tag}`] = increment(1)
+      }
+      await updateDoc(docRef, payload)
     },
   })
 }

--- a/app/types/Friendship.ts
+++ b/app/types/Friendship.ts
@@ -1,0 +1,17 @@
+import type { Timestamp } from 'firebase/firestore'
+
+export type FriendshipStatus = 'pending' | 'accepted' | 'declined'
+
+export type Friendship = {
+  id: string
+  uids: [string, string]
+  requesterUid: string
+  status: FriendshipStatus
+  requestedAt: Timestamp
+  respondedAt?: Timestamp
+  declinedAt?: Timestamp
+}
+
+export function buildFriendshipId(uid1: string, uid2: string): string {
+  return [uid1, uid2].sort().join('_')
+}

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -19,6 +19,7 @@ export type User = {
   website?: string
   lastUpdated?: Timestamp
   createdAt?: Timestamp
+  tagCounts?: Record<string, number>
   preferences?: {
     theme?: 'light' | 'dark'
     hasSeenPackingListTour?: boolean

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -24,6 +24,7 @@ export type User = {
     hasSeenPackingListTour?: boolean
     hasDismissedFernwoodAd?: Timestamp
     safetyItineraryEnabled?: boolean
+    friendRequestEmailEnabled?: boolean
     temperatureUnit?: 'celsius' | 'fahrenheit'
   }
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}


### PR DESCRIPTION
## Summary

- Adds `tagCounts?: Record<string, number>` as a top-level optional field on the `User` type
- Implements `getFrequentTags(tagCounts, customTags, cap)` pure utility and exports `FREQUENT_TAGS_CAP = 6`
- Switches `predefinedKeySet` to use the pre-computed `gearListKeys` export instead of re-mapping `allGearListItems`
- Removes redundant empty-object early return (empty `tagCounts` already yields `[]` via `Object.entries`)
- Improves test names and data to use confirmed predefined keys, avoiding false assumptions about which tags are predefined

## Test plan

- [ ] `pnpm test` passes (132 tests, 18 suites)
- [ ] `pnpm typecheck` passes
- [ ] Empty/absent `tagCounts` returns `[]`
- [ ] Tags sorted by count descending, capped at 6
- [ ] Ghost custom tags (deleted from Gear Closet) are filtered out
- [ ] Predefined tags are never filtered out

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)