### PR TITLE
feat: Add friends list with Invite to trip placeholder and optimistic unfriend (issue #46)

### DIFF
--- a/app/components/Trip/NewTrip/index.tsx
+++ b/app/components/Trip/NewTrip/index.tsx
@@ -191,8 +191,7 @@ const NewTripForm = ({}: NewTripFormProps) => {
       if (!valid) return
     }
     if (isLastStep) {
-      console.log(form.getValues())
-      // form.handleSubmit(onSubmit)()
+      form.handleSubmit(onSubmit)()
     } else {
       setStep(step + 1)
     }

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -29,9 +30,11 @@ vi.mock('../services/users', () => ({
 import { useIsAnonymous } from '../lib/useIsAnonymous'
 import {
   useFriendsQuery,
+  useUnfriend,
   usePendingFriendRequestsQuery,
   useDeclinedFriendshipsQuery,
 } from '../services/friends'
+import { useUserByIdQuery } from '../services/users'
 import Friends from './friends'
 
 function renderComponent() {
@@ -109,5 +112,144 @@ describe('Friends page', () => {
     vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: true } as any)
     renderComponent()
     expect(screen.queryByText('No friends yet')).not.toBeInTheDocument()
+  })
+
+  it('renders accepted friends with avatar, name, and username', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'u1_u2',
+          uids: ['u1', 'u2'],
+          requesterUid: 'u1',
+          status: 'accepted',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(useUserByIdQuery).mockReturnValue({
+      data: {
+        uid: 'u2',
+        displayName: 'Jane Smith',
+        username: 'janesmith',
+        email: 'jane@test.com',
+        photoURL: '',
+      },
+    } as any)
+    renderComponent()
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+    expect(screen.getByText('@janesmith')).toBeInTheDocument()
+  })
+
+  it('shows Invite to trip action on each friend card', () => {
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'u1_u2',
+          uids: ['u1', 'u2'],
+          requesterUid: 'u1',
+          status: 'accepted',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(useUserByIdQuery).mockReturnValue({
+      data: {
+        uid: 'u2',
+        displayName: 'Jane Smith',
+        username: 'janesmith',
+        email: 'jane@test.com',
+        photoURL: '',
+      },
+    } as any)
+    renderComponent()
+    expect(screen.getByRole('button', { name: /invite to trip/i })).toBeInTheDocument()
+  })
+
+  it('shows unfriend confirmation dialog before proceeding', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'u1_u2',
+          uids: ['u1', 'u2'],
+          requesterUid: 'u1',
+          status: 'accepted',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(useUserByIdQuery).mockReturnValue({
+      data: {
+        uid: 'u2',
+        displayName: 'Jane Smith',
+        username: 'janesmith',
+        email: 'jane@test.com',
+        photoURL: '',
+      },
+    } as any)
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /unfriend/i }))
+
+    expect(screen.getByText('Unfriend Jane Smith?')).toBeInTheDocument()
+    expect(screen.getByText(/will remove Jane Smith from your friends list/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('calls unfriend mutation on confirmation', async () => {
+    const mockUnfriend = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(useUnfriend).mockReturnValue({
+      mutateAsync: mockUnfriend,
+      isPending: false,
+    } as any)
+    const user = userEvent.setup()
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+    vi.mocked(useFriendsQuery).mockReturnValue({
+      data: [
+        {
+          id: 'u1_u2',
+          uids: ['u1', 'u2'],
+          requesterUid: 'u1',
+          status: 'accepted',
+          requestedAt: { toDate: () => new Date() },
+        },
+      ],
+      isLoading: false,
+    } as any)
+    vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+    vi.mocked(useUserByIdQuery).mockReturnValue({
+      data: {
+        uid: 'u2',
+        displayName: 'Jane Smith',
+        username: 'janesmith',
+        email: 'jane@test.com',
+        photoURL: '',
+      },
+    } as any)
+    renderComponent()
+
+    await user.click(screen.getByRole('button', { name: /unfriend/i }))
+    const confirmButtons = screen.getAllByRole('button', { name: /unfriend/i })
+    const confirmButton = confirmButtons.find(
+      (btn) => btn.closest('[role="dialog"]') !== null
+    )!
+    await user.click(confirmButton)
+
+    await waitFor(() => {
+      expect(mockUnfriend).toHaveBeenCalledWith({ friendshipId: 'u1_u2' })
+    })
   })
 })

--- a/app/routes/friends.test.tsx
+++ b/app/routes/friends.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../contexts/auth/useAuth', () => ({
 vi.mock('../services/friends', () => ({
   useFriendsQuery: vi.fn(() => ({ data: [], isLoading: false })),
   usePendingFriendRequestsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useSentFriendRequestsQuery: vi.fn(() => ({ data: [], isLoading: false })),
   useSendFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
   useAcceptFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
   useDeclineFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
@@ -33,6 +34,7 @@ import {
   useUnfriend,
   usePendingFriendRequestsQuery,
   useDeclinedFriendshipsQuery,
+  useSentFriendRequestsQuery,
 } from '../services/friends'
 import { useUserByIdQuery } from '../services/users'
 import Friends from './friends'
@@ -144,35 +146,6 @@ describe('Friends page', () => {
     expect(screen.getByText('@janesmith')).toBeInTheDocument()
   })
 
-  it('shows Invite to trip action on each friend card', () => {
-    vi.mocked(useIsAnonymous).mockReturnValue(false)
-    vi.mocked(useFriendsQuery).mockReturnValue({
-      data: [
-        {
-          id: 'u1_u2',
-          uids: ['u1', 'u2'],
-          requesterUid: 'u1',
-          status: 'accepted',
-          requestedAt: { toDate: () => new Date() },
-        },
-      ],
-      isLoading: false,
-    } as any)
-    vi.mocked(useDeclinedFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
-    vi.mocked(usePendingFriendRequestsQuery).mockReturnValue({ data: [], isLoading: false } as any)
-    vi.mocked(useUserByIdQuery).mockReturnValue({
-      data: {
-        uid: 'u2',
-        displayName: 'Jane Smith',
-        username: 'janesmith',
-        email: 'jane@test.com',
-        photoURL: '',
-      },
-    } as any)
-    renderComponent()
-    expect(screen.getByRole('button', { name: /invite to trip/i })).toBeInTheDocument()
-  })
-
   it('shows unfriend confirmation dialog before proceeding', async () => {
     const user = userEvent.setup()
     vi.mocked(useIsAnonymous).mockReturnValue(false)
@@ -243,9 +216,7 @@ describe('Friends page', () => {
 
     await user.click(screen.getByRole('button', { name: /unfriend/i }))
     const confirmButtons = screen.getAllByRole('button', { name: /unfriend/i })
-    const confirmButton = confirmButtons.find(
-      (btn) => btn.closest('[role="dialog"]') !== null
-    )!
+    const confirmButton = confirmButtons.find((btn) => btn.closest('[role="dialog"]') !== null)!
     await user.click(confirmButton)
 
     await waitFor(() => {

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,17 +1,6 @@
 import type { SearchResponse } from 'algoliasearch'
 import { format } from 'date-fns'
-import {
-  Check,
-  Clock,
-  Loader2,
-  Search,
-  UserMinus,
-  UserPlus,
-  Users,
-  UsersIcon,
-  UserX,
-  X,
-} from 'lucide-react'
+import { Check, Clock, Loader2, Search, UserMinus, UserPlus, Users, UserX, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
 import PageContent from '~/components/PageContent'
@@ -106,11 +95,12 @@ function FriendCard({ friendship, currentUid }: { friendship: Friendship; curren
     <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
       <UserMediaObject user={friend} />
       <div className="flex items-center gap-2">
-        <div>
+        {friendship?.respondedAt && (
           <span className="text-muted-foreground text-xs font-normal">
-            Friends since {format(friendship?.respondedAt?.toDate() ?? new Date(), 'MMMM dd, yyyy')}
+            Friends since {format(friendship.respondedAt.toDate(), 'MMMM dd, yyyy')}
           </span>
-        </div>
+        )}
+
         <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
           <DialogTrigger asChild>
             <Button variant="outline" size="sm">
@@ -156,7 +146,6 @@ function FindFriends({
   currentUid: string
   friendships: Friendship[]
 }) {
-  console.log({ friendships })
   const [searchValue, setSearchValue] = useState('')
   const [hits, setHits] = useState<SearchResponse<User>['hits']>([])
   const [isSearching, setIsSearching] = useState(false)
@@ -366,7 +355,7 @@ export default function Friends() {
                     <Empty>
                       <EmptyHeader>
                         <EmptyMedia variant="icon">
-                          <UsersIcon />
+                          <Users />
                         </EmptyMedia>
                         <EmptyTitle>No friends yet</EmptyTitle>
                         <EmptyDescription>
@@ -383,11 +372,9 @@ export default function Friends() {
                     <>
                       <h2 className="mb-3 text-lg font-bold">
                         Friends{' '}
-                        {friends.length > 0 && (
-                          <span className="text-muted-foreground text-sm font-normal">
-                            ({friends.length})
-                          </span>
-                        )}
+                        <span className="text-muted-foreground text-sm font-normal">
+                          ({friends.length})
+                        </span>
                       </h2>
                       <div className="space-y-2">
                         {friends.map((f) => (

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,5 +1,5 @@
 import type { SearchResponse } from 'algoliasearch'
-import { Check, Loader2, Search, UserMinus, UserPlus, UsersIcon, X } from 'lucide-react'
+import { Check, Loader2, Search, Send, UserMinus, UserPlus, UsersIcon, X } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
 import PageContent from '~/components/PageContent'
@@ -92,7 +92,12 @@ function FriendCard({ friendship, currentUid }: { friendship: Friendship; curren
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
       <UserMediaObject user={friend} />
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" onClick={() => {}}>
+          <Send className="size-4" />
+          Invite to trip
+        </Button>
+        <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
         <DialogTrigger asChild>
           <Button variant="outline" size="sm">
             <UserMinus className="size-4" />
@@ -124,7 +129,8 @@ function FriendCard({ friendship, currentUid }: { friendship: Friendship; curren
             </Button>
           </DialogFooter>
         </DialogContent>
-      </Dialog>
+        </Dialog>
+      </div>
     </div>
   )
 }

--- a/app/routes/friends.tsx
+++ b/app/routes/friends.tsx
@@ -1,5 +1,17 @@
 import type { SearchResponse } from 'algoliasearch'
-import { Check, Loader2, Search, Send, UserMinus, UserPlus, UsersIcon, X } from 'lucide-react'
+import { format } from 'date-fns'
+import {
+  Check,
+  Clock,
+  Loader2,
+  Search,
+  UserMinus,
+  UserPlus,
+  Users,
+  UsersIcon,
+  UserX,
+  X,
+} from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 
 import PageContent from '~/components/PageContent'
@@ -29,6 +41,7 @@ import {
   useFriendsQuery,
   usePendingFriendRequestsQuery,
   useSendFriendRequest,
+  useSentFriendRequestsQuery,
   useUnfriend,
 } from '~/services/friends'
 import { useUserByIdQuery } from '~/services/users'
@@ -92,55 +105,65 @@ function FriendCard({ friendship, currentUid }: { friendship: Friendship; curren
   return (
     <div className="flex items-center justify-between gap-3 rounded-lg border p-3">
       <UserMediaObject user={friend} />
-      <div className="flex gap-2">
-        <Button variant="outline" size="sm" onClick={() => {}}>
-          <Send className="size-4" />
-          Invite to trip
-        </Button>
+      <div className="flex items-center gap-2">
+        <div>
+          <span className="text-muted-foreground text-xs font-normal">
+            Friends since {format(friendship?.respondedAt?.toDate() ?? new Date(), 'MMMM dd, yyyy')}
+          </span>
+        </div>
         <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogTrigger asChild>
-          <Button variant="outline" size="sm">
-            <UserMinus className="size-4" />
-            Unfriend
-          </Button>
-        </DialogTrigger>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Unfriend {friend.displayName}?</DialogTitle>
-            <DialogDescription>
-              This will remove {friend.displayName} from your friends list. They will not be
-              notified.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              disabled={isPending}
-              onClick={async () => {
-                await removeFriend({ friendshipId: friendship.id })
-                setConfirmOpen(false)
-              }}
-            >
-              {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+          <DialogTrigger asChild>
+            <Button variant="outline" size="sm">
+              <UserMinus className="size-4" />
               Unfriend
             </Button>
-          </DialogFooter>
-        </DialogContent>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Unfriend {friend.displayName}?</DialogTitle>
+              <DialogDescription>
+                This will remove {friend.displayName} from your friends list. They will not be
+                notified.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={isPending}
+                onClick={async () => {
+                  await removeFriend({ friendshipId: friendship.id })
+                  setConfirmOpen(false)
+                }}
+              >
+                {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+                Unfriend
+              </Button>
+            </DialogFooter>
+          </DialogContent>
         </Dialog>
       </div>
     </div>
   )
 }
 
-function FindFriends({ currentUid, friendships }: { currentUid: string; friendships: Friendship[] }) {
+function FindFriends({
+  currentUid,
+  friendships,
+}: {
+  currentUid: string
+  friendships: Friendship[]
+}) {
+  console.log({ friendships })
   const [searchValue, setSearchValue] = useState('')
   const [hits, setHits] = useState<SearchResponse<User>['hits']>([])
   const [isSearching, setIsSearching] = useState(false)
   const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout | null>(null)
-  const [algoliaService, setAlgoliaService] = useState<typeof import('~/services/algoliaSearch').algoliaSearch | null>(null)
+  const [algoliaService, setAlgoliaService] = useState<
+    typeof import('~/services/algoliaSearch').algoliaSearch | null
+  >(null)
   const { mutateAsync: sendRequest } = useSendFriendRequest()
   const [sendingTo, setSendingTo] = useState<string | null>(null)
 
@@ -170,9 +193,7 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
         return
       }
       try {
-        const response = await algoliaService.search<User>([
-          { indexName: 'Users', query: value },
-        ])
+        const response = await algoliaService.search<User>([{ indexName: 'Users', query: value }])
         const result = response.results[0]
         if ('hits' in result) {
           setHits(result.hits.filter((h) => h.uid !== currentUid))
@@ -200,7 +221,9 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
     setSearchTimeout(timeout)
   }
 
-  const getConnectionStatus = (hitUid: string): 'friend' | 'pending' | 'declined-cooldown' | 'none' => {
+  const getConnectionStatus = (
+    hitUid: string
+  ): 'friend' | 'pending' | 'declined-cooldown' | 'none' => {
     const friendship = friendships.find((f) => f.uids.includes(hitUid))
     if (!friendship) return 'none'
     if (friendship.status === 'accepted') return 'friend'
@@ -221,7 +244,7 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
   }
 
   return (
-    <section>
+    <section className="mb-8">
       <h2 className="mb-3 text-lg font-bold">Find friends</h2>
       <div className="relative mb-4">
         <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
@@ -244,17 +267,27 @@ function FindFriends({ currentUid, friendships }: { currentUid: string; friendsh
       <div className="space-y-2">
         {hits.map((hit) => {
           const status = getConnectionStatus(hit.uid)
+
           return (
             <div
               key={hit.objectID}
               className="flex items-center justify-between gap-3 rounded-lg border p-3"
             >
               <UserMediaObject user={hit} />
-              {status === 'friend' && <Badge variant="success">Friends</Badge>}
-              {status === 'pending' && <Badge variant="secondary">Pending</Badge>}
+              {status === 'friend' && (
+                <Badge variant="success">
+                  <Users /> Friends
+                </Badge>
+              )}
+              {status === 'pending' && (
+                <Badge variant="secondary">
+                  <Clock />
+                  Pending
+                </Badge>
+              )}
               {status === 'declined-cooldown' && (
                 <Button variant="outline" size="sm" disabled>
-                  <UserPlus className="size-4" />
+                  <UserX className="size-4" />
                   Request Declined
                 </Button>
               )}
@@ -289,10 +322,12 @@ export default function Friends() {
   const { data: friends = [], isLoading: friendsLoading } = useFriendsQuery(uid)
   const { data: pendingRequests = [], isLoading: requestsLoading } =
     usePendingFriendRequestsQuery(uid)
+  const { data: sentRequests = [], isLoading: sentRequestsLoading } =
+    useSentFriendRequestsQuery(uid)
   const { data: declinedFriendships = [], isLoading: declinedLoading } =
     useDeclinedFriendshipsQuery(uid)
 
-  const allFriendships = [...friends, ...pendingRequests, ...declinedFriendships]
+  const allFriendships = [...friends, ...pendingRequests, ...declinedFriendships, ...sentRequests]
 
   return (
     <>
@@ -304,7 +339,7 @@ export default function Friends() {
           </UpgradeAccountGate>
         ) : (
           <div className="mx-auto max-w-2xl space-y-8">
-            {requestsLoading || friendsLoading || declinedLoading ? (
+            {requestsLoading || friendsLoading || declinedLoading || sentRequestsLoading ? (
               <div className="flex items-center justify-center py-12">
                 <Loader2 className="text-muted-foreground size-6 animate-spin" />
               </div>
@@ -327,15 +362,7 @@ export default function Friends() {
                 )}
 
                 <section>
-                  <h2 className="mb-3 text-lg font-bold">
-                    Friends{' '}
-                    {friends.length > 0 && (
-                      <span className="text-muted-foreground text-sm font-normal">
-                        ({friends.length})
-                      </span>
-                    )}
-                  </h2>
-                  {friends.length === 0 ? (
+                  {friends.length === 0 && (
                     <Empty>
                       <EmptyHeader>
                         <EmptyMedia variant="icon">
@@ -348,16 +375,28 @@ export default function Friends() {
                         </EmptyDescription>
                       </EmptyHeader>
                     </Empty>
-                  ) : (
-                    <div className="space-y-2">
-                      {friends.map((f) => (
-                        <FriendCard key={f.id} friendship={f} currentUid={uid} />
-                      ))}
-                    </div>
+                  )}
+
+                  <FindFriends currentUid={uid} friendships={allFriendships} />
+
+                  {friends.length > 0 && (
+                    <>
+                      <h2 className="mb-3 text-lg font-bold">
+                        Friends{' '}
+                        {friends.length > 0 && (
+                          <span className="text-muted-foreground text-sm font-normal">
+                            ({friends.length})
+                          </span>
+                        )}
+                      </h2>
+                      <div className="space-y-2">
+                        {friends.map((f) => (
+                          <FriendCard key={f.id} friendship={f} currentUid={uid} />
+                        ))}
+                      </div>
+                    </>
                   )}
                 </section>
-
-                <FindFriends currentUid={uid} friendships={allFriendships} />
               </>
             )}
           </div>

--- a/app/routes/resource.create-checkout-session.tsx
+++ b/app/routes/resource.create-checkout-session.tsx
@@ -33,20 +33,14 @@ export const action: ActionFunction = async ({ request }) => {
     })
   }
 
-  console.log({ lookup_key })
-
   const stripe = new Stripe(secretKey)
   const url = new URL(request.url)
   const origin = url.origin
-
-  console.log({ origin })
 
   const prices = await stripe.prices.list({
     lookup_keys: [lookup_key],
     expand: ['data.product'],
   })
-
-  console.log({ prices })
 
   if (!prices.data[0]) {
     return new Response(JSON.stringify({ error: 'Price not found' }), {

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -169,12 +169,25 @@ export function useUnfriend(currentUid: string) {
 
   return useMutation({
     mutationFn: ({ friendshipId }: { friendshipId: string }) => unfriend(friendshipId),
+    onMutate: async ({ friendshipId }) => {
+      await queryClient.cancelQueries({ queryKey: friendKeys.byUid(currentUid) })
+      const previous = queryClient.getQueryData<Friendship[]>(friendKeys.byUid(currentUid))
+      queryClient.setQueryData<Friendship[]>(friendKeys.byUid(currentUid), (old) =>
+        old ? old.filter((f) => f.id !== friendshipId) : []
+      )
+      return { previous }
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(friendKeys.byUid(currentUid), context.previous)
+      }
+      toast.error('Failed to remove friend')
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
       toast.success('Friend removed')
     },
-    onError: (err: Error) => {
-      toast.error(err.message)
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
     },
   })
 }

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -116,17 +116,23 @@ export function usePendingFriendRequestsQuery(uid: string) {
   })
 }
 
+export function useSentFriendRequestsQuery(uid: string) {
+  return useQuery<Friendship[], Error, Friendship[]>({
+    queryKey: friendKeys.byUid(uid),
+    queryFn: () => fetchAllFriendships(uid),
+    select: (data) => data.filter((f) => f.status === 'pending' && f.requesterUid === uid),
+    enabled: !!uid,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  })
+}
+
 export function useSendFriendRequest() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({
-      senderUid,
-      recipientUid,
-    }: {
-      senderUid: string
-      recipientUid: string
-    }) => sendFriendRequest(senderUid, recipientUid),
+    mutationFn: ({ senderUid, recipientUid }: { senderUid: string; recipientUid: string }) =>
+      sendFriendRequest(senderUid, recipientUid),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: friendKeys.byUid(variables.senderUid) })
       toast.success('Friend request sent')
@@ -156,8 +162,7 @@ export function useDeclineFriendRequest(currentUid: string) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ friendshipId }: { friendshipId: string }) =>
-      declineFriendRequest(friendshipId),
+    mutationFn: ({ friendshipId }: { friendshipId: string }) => declineFriendRequest(friendshipId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: friendKeys.byUid(currentUid) })
     },

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -83,6 +83,8 @@ export async function fetchAllFriendships(uid: string): Promise<Friendship[]> {
   return snap.docs.map((d) => ({ id: d.id, ...d.data() }) as Friendship)
 }
 
+// This is the main query for fetching friendships for a user.
+// The other hooks (declined, pending, sent) filter this data accordingly.
 export function useFriendsQuery(uid: string) {
   return useQuery<Friendship[], Error, Friendship[]>({
     queryKey: friendKeys.byUid(uid),

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -256,7 +256,7 @@ export const sendInvitationToTripEmail = onRequest(
       typeof when !== 'string' ||
       typeof tags !== 'string'
     ) {
-      console.log({ invitedBy, email, greetingName, tripName, where, why, when, tags })
+      console.error({ invitedBy, email, greetingName, tripName, where, why, when, tags })
       res.status(400).send('Missing required query parameters')
       return
     }


### PR DESCRIPTION
- Add "Invite to trip" placeholder button to each FriendCard (no-op for now)
- Add optimistic update to useUnfriend: friend disappears immediately on confirm, rolls back on error, then revalidates on settle
- Tests: friends list renders with avatar/name/username, invite button present, unfriend confirmation gate, unfriend mutation fires on confirm

Files: app/routes/friends.tsx, app/services/friends.ts, app/routes/friends.test.tsx