### PR TITLE
feat: Friends-first trip invite dialog with bundled Friend Request (issue #48)

### DIFF
--- a/app/components/Trip/AddTripPartyMember.test.tsx
+++ b/app/components/Trip/AddTripPartyMember.test.tsx
@@ -1,7 +1,12 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockUpdateTrip = vi.fn(() => Promise.resolve())
+const mockSendMessage = vi.fn(() => Promise.resolve())
+const mockSendFriendReq = vi.fn(() => Promise.resolve())
+const mockFetcherSubmit = vi.fn(() => Promise.resolve())
 
 vi.mock('../../lib/useIsAnonymous', () => ({
   useIsAnonymous: vi.fn(),
@@ -13,17 +18,24 @@ vi.mock('../../contexts/auth/useAuth', () => ({
 }))
 
 vi.mock('../../services/trips', () => ({
-  useUpdateTrip: vi.fn(() => ({ mutateAsync: vi.fn() })),
-  useCreateChatMessage: vi.fn(() => ({ mutateAsync: vi.fn() })),
+  useUpdateTrip: vi.fn(() => ({ mutateAsync: mockUpdateTrip })),
+  useCreateChatMessage: vi.fn(() => ({ mutateAsync: mockSendMessage })),
 }))
 
 vi.mock('../../services/friends', () => ({
   useFriendsQuery: vi.fn(() => ({ data: [], isLoading: false })),
-  useSendFriendRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  usePendingFriendshipsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useSendFriendRequest: vi.fn(() => ({ mutateAsync: mockSendFriendReq, isPending: false })),
 }))
 
 vi.mock('../../services/users', () => ({
   useUserByIdQuery: vi.fn(() => ({ data: null })),
+}))
+
+vi.mock('../../services/algoliaSearch', () => ({
+  algoliaSearch: {
+    search: vi.fn(() => Promise.resolve({ results: [{ hits: [] }] })),
+  },
 }))
 
 vi.mock('react-router', async () => {
@@ -31,24 +43,32 @@ vi.mock('react-router', async () => {
   return {
     ...actual,
     useParams: vi.fn(() => ({ id: 'trip1' })),
-    useFetcher: vi.fn(() => ({ submit: vi.fn() })),
+    useFetcher: vi.fn(() => ({ submit: mockFetcherSubmit })),
   }
 })
 
+import { useFriendsQuery, usePendingFriendshipsQuery, useSendFriendRequest } from '../../services/friends'
 import { useIsAnonymous } from '../../lib/useIsAnonymous'
+import { useUserByIdQuery } from '../../services/users'
+import { algoliaSearch } from '../../services/algoliaSearch'
 import { AddTripPartyMember } from './AddTripPartyMember'
 
 const GATE_MESSAGE = 'Create an account to invite friends and assign gear to your crew.'
 
-function renderComponent() {
+function renderComponent(tripMembers: any[] = []) {
   return render(
     <MemoryRouter>
-      <AddTripPartyMember trip={{ tripId: 'trip1' } as any} tripMembers={[]} />
+      <AddTripPartyMember trip={{ tripId: 'trip1', name: 'Test Trip', startingPoint: 'Denver', description: 'Fun', tags: ['hiking'], startDate: { seconds: 1700000000 }, endDate: { seconds: 1700100000 } } as any} tripMembers={tripMembers} />
     </MemoryRouter>
   )
 }
 
 describe('AddTripPartyMember', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useIsAnonymous).mockReturnValue(false)
+  })
+
   it('shows a visible add-member button for anonymous users', () => {
     vi.mocked(useIsAnonymous).mockReturnValue(true)
     renderComponent()
@@ -70,8 +90,155 @@ describe('AddTripPartyMember', () => {
   })
 
   it('renders the popover trigger for registered users', () => {
-    vi.mocked(useIsAnonymous).mockReturnValue(false)
     renderComponent()
     expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument()
+  })
+
+  describe('friends-first invite', () => {
+    it('shows friends above the search input when popover opens', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({
+        data: [
+          { id: 'u1_u2', uids: ['u1', 'u2'], requesterUid: 'u1', status: 'accepted', requestedAt: {} as any },
+        ],
+        isLoading: false,
+      } as any)
+      vi.mocked(useUserByIdQuery).mockReturnValue({
+        data: { uid: 'u2', username: 'frienduser', email: 'friend@test.com', displayName: 'Friend User' },
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      expect(screen.getByText('Friends')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /add frienduser to trip/i })).toBeInTheDocument()
+    })
+
+    it('shows bundled friend request checkbox for non-friend search results', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(usePendingFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(algoliaSearch.search).mockResolvedValue({
+        results: [{ hits: [{ objectID: 'obj1', uid: 'stranger1', username: 'stranger', email: 's@test.com' }] }],
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      const input = screen.getByPlaceholderText(/search by username/i)
+      await userEvent.type(input, 'stranger')
+
+      await waitFor(() => {
+        expect(screen.getByText(/also send stranger a friend request/i)).toBeInTheDocument()
+      })
+    })
+
+    it('does not send friend request when checkbox is unchecked', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(usePendingFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(algoliaSearch.search).mockResolvedValue({
+        results: [{ hits: [{ objectID: 'obj1', uid: 'stranger1', username: 'stranger', email: 's@test.com' }] }],
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      const input = screen.getByPlaceholderText(/search by username/i)
+      await userEvent.type(input, 'stranger')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add stranger to trip/i })).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('button', { name: /add stranger to trip/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateTrip).toHaveBeenCalled()
+      })
+      expect(mockSendFriendReq).not.toHaveBeenCalled()
+    })
+
+    it('sends both trip invitation and friend request when checkbox is checked', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(usePendingFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(algoliaSearch.search).mockResolvedValue({
+        results: [{ hits: [{ objectID: 'obj1', uid: 'stranger1', username: 'stranger', email: 's@test.com' }] }],
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      const input = screen.getByPlaceholderText(/search by username/i)
+      await userEvent.type(input, 'stranger')
+
+      await waitFor(() => {
+        expect(screen.getByText(/also send stranger a friend request/i)).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByRole('checkbox'))
+      await userEvent.click(screen.getByRole('button', { name: /add stranger to trip/i }))
+
+      await waitFor(() => {
+        expect(mockUpdateTrip).toHaveBeenCalled()
+      })
+      await waitFor(() => {
+        expect(mockSendFriendReq).toHaveBeenCalledWith({ senderUid: 'u1', recipientUid: 'stranger1' })
+      })
+    })
+
+    it('filters out friends from Algolia search results', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({
+        data: [
+          { id: 'u1_u2', uids: ['u1', 'u2'], requesterUid: 'u1', status: 'accepted', requestedAt: {} as any },
+        ],
+        isLoading: false,
+      } as any)
+      vi.mocked(usePendingFriendshipsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(useUserByIdQuery).mockReturnValue({
+        data: { uid: 'u2', username: 'frienduser', email: 'friend@test.com', displayName: 'Friend User' },
+      } as any)
+      vi.mocked(algoliaSearch.search).mockResolvedValue({
+        results: [{ hits: [
+          { objectID: 'obj1', uid: 'u2', username: 'frienduser', email: 'friend@test.com' },
+          { objectID: 'obj2', uid: 'stranger1', username: 'stranger', email: 's@test.com' },
+        ] }],
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      const input = screen.getByPlaceholderText(/search by username/i)
+      await userEvent.type(input, 'friend')
+
+      await waitFor(() => {
+        expect(screen.getByText(/also send stranger a friend request/i)).toBeInTheDocument()
+      })
+      expect(screen.queryByText(/also send frienduser a friend request/i)).not.toBeInTheDocument()
+    })
+
+    it('filters out users with pending friend requests from Algolia results', async () => {
+      vi.mocked(useFriendsQuery).mockReturnValue({ data: [], isLoading: false } as any)
+      vi.mocked(usePendingFriendshipsQuery).mockReturnValue({
+        data: [
+          { id: 'u1_u3', uids: ['u1', 'u3'], requesterUid: 'u1', status: 'pending', requestedAt: {} as any },
+        ],
+        isLoading: false,
+      } as any)
+      vi.mocked(algoliaSearch.search).mockResolvedValue({
+        results: [{ hits: [
+          { objectID: 'obj1', uid: 'u3', username: 'pendinguser', email: 'p@test.com' },
+          { objectID: 'obj2', uid: 'stranger1', username: 'stranger', email: 's@test.com' },
+        ] }],
+      } as any)
+
+      renderComponent()
+      await userEvent.click(screen.getByRole('button', { name: /add member/i }))
+
+      const input = screen.getByPlaceholderText(/search by username/i)
+      await userEvent.type(input, 'user')
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /add stranger to trip/i })).toBeInTheDocument()
+      })
+      expect(screen.queryByRole('button', { name: /add pendinguser to trip/i })).not.toBeInTheDocument()
+    })
   })
 })

--- a/app/components/Trip/AddTripPartyMember.tsx
+++ b/app/components/Trip/AddTripPartyMember.tsx
@@ -423,50 +423,50 @@ export function AddTripPartyMember({
                     hits
                       .filter((hit) => !isPending(hit.uid))
                       .map((hit) => {
-                      const matchingUser = tripMembers.find((member) => member.uid === hit.uid)
-                      const hitIsFriend = isFriend(hit.uid)
-                      return (
-                        <div key={hit.objectID}>
-                          <div className="text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors">
-                            <UserMediaObject user={hit} />
-                            {matchingUser ? (
-                              <TripPartyMemberBadge member={matchingUser} />
-                            ) : (
-                              <Button
-                                type="button"
-                                variant="outline"
-                                size="icon"
-                                onClick={() =>
-                                  addMemberToTrip(hit.uid, hit.email, hit.username)
-                                }
-                                disabled={isAddingMember === hit.uid}
-                              >
-                                {isAddingMember === hit.uid ? (
-                                  <Loader2 className="size-4 animate-spin" />
-                                ) : (
-                                  <Plus />
-                                )}
-                                <span className="sr-only">Add {hit.username} to trip</span>
-                              </Button>
+                        const matchingUser = tripMembers.find((member) => member.uid === hit.uid)
+                        const hitIsFriend = isFriend(hit.uid)
+                        return (
+                          <div key={hit.objectID}>
+                            <div className="text-sidebar-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent flex items-center justify-between gap-2 rounded-lg px-3 py-2 transition-colors">
+                              <UserMediaObject user={hit} />
+                              {matchingUser ? (
+                                <TripPartyMemberBadge member={matchingUser} />
+                              ) : (
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="icon"
+                                  onClick={() =>
+                                    addMemberToTrip(hit.uid, hit.email, hit.username)
+                                  }
+                                  disabled={isAddingMember === hit.uid}
+                                >
+                                  {isAddingMember === hit.uid ? (
+                                    <Loader2 className="size-4 animate-spin" />
+                                  ) : (
+                                    <Plus />
+                                  )}
+                                  <span className="sr-only">Add {hit.username} to trip</span>
+                                </Button>
+                              )}
+                            </div>
+                            {!matchingUser && !hitIsFriend && (
+                              <label className="text-muted-foreground flex items-center gap-2 px-3 py-1 text-xs">
+                                <Checkbox
+                                  checked={sendFriendRequestFor[hit.uid] ?? false}
+                                  onCheckedChange={(checked) =>
+                                    setSendFriendRequestFor((prev) => ({
+                                      ...prev,
+                                      [hit.uid]: !!checked,
+                                    }))
+                                  }
+                                />
+                                Also send {hit.username} a Friend Request
+                              </label>
                             )}
                           </div>
-                          {!matchingUser && !hitIsFriend && (
-                            <label className="text-muted-foreground flex items-center gap-2 px-3 py-1 text-xs">
-                              <Checkbox
-                                checked={sendFriendRequestFor[hit.uid] ?? false}
-                                onCheckedChange={(checked) =>
-                                  setSendFriendRequestFor((prev) => ({
-                                    ...prev,
-                                    [hit.uid]: !!checked,
-                                  }))
-                                }
-                              />
-                              Also send {hit.username} a Friend Request
-                            </label>
-                          )}
-                        </div>
-                      )
-                    })}
+                        )
+                      })}
                 </div>
               </div>
             </form>

--- a/app/components/Trip/AddTripPartyMember.tsx
+++ b/app/components/Trip/AddTripPartyMember.tsx
@@ -23,7 +23,7 @@ import { createSystemMessage } from '~/lib/chat'
 import { formattedDateRange } from '~/lib/date'
 import { useIsAnonymous } from '~/lib/useIsAnonymous'
 import { algoliaSearch } from '~/services/algoliaSearch'
-import { useFriendsQuery, useSendFriendRequest } from '~/services/friends'
+import { useFriendsQuery, usePendingFriendshipsQuery, useSendFriendRequest } from '~/services/friends'
 import { useCreateChatMessage, useUpdateTrip } from '~/services/trips'
 import { useUserByIdQuery } from '~/services/users'
 import type { Trip } from '~/types/Trip'
@@ -100,6 +100,7 @@ export function AddTripPartyMember({
   const fetcher = useFetcher()
 
   const { data: friendships = [] } = useFriendsQuery(user?.uid ?? '')
+  const { data: pendingFriendships = [] } = usePendingFriendshipsQuery(user?.uid ?? '')
   const { mutateAsync: sendFriendReq } = useSendFriendRequest()
   const [sendFriendRequestFor, setSendFriendRequestFor] = useState<Record<string, boolean>>({})
 
@@ -114,7 +115,12 @@ export function AddTripPartyMember({
     f.uids.find((uid) => uid !== user?.uid) ?? ''
   ).filter(Boolean)
 
+  const pendingUids = pendingFriendships.map((f) =>
+    f.uids.find((uid) => uid !== user?.uid) ?? ''
+  ).filter(Boolean)
+
   const isFriend = (uid: string) => friendUids.includes(uid)
+  const isPending = (uid: string) => pendingUids.includes(uid)
 
   // Prevent hydration mismatch by only allowing username checking after hydration
   useEffect(() => {
@@ -414,7 +420,9 @@ export function AddTripPartyMember({
                 />
                 <div className="max-h-[200px] space-y-2 overflow-y-auto">
                   {hits.length > 0 &&
-                    hits.map((hit) => {
+                    hits
+                      .filter((hit) => !isPending(hit.uid))
+                      .map((hit) => {
                       const matchingUser = tripMembers.find((member) => member.uid === hit.uid)
                       const hitIsFriend = isFriend(hit.uid)
                       return (

--- a/app/services/friends.ts
+++ b/app/services/friends.ts
@@ -116,6 +116,17 @@ export function usePendingFriendRequestsQuery(uid: string) {
   })
 }
 
+export function usePendingFriendshipsQuery(uid: string) {
+  return useQuery<Friendship[], Error, Friendship[]>({
+    queryKey: friendKeys.byUid(uid),
+    queryFn: () => fetchAllFriendships(uid),
+    select: (data) => data.filter((f) => f.status === 'pending'),
+    enabled: !!uid,
+    refetchOnWindowFocus: false,
+    refetchOnMount: true,
+  })
+}
+
 export function useSendFriendRequest() {
   const queryClient = useQueryClient()
 


### PR DESCRIPTION


- Friends pre-loaded at top of popover without typing required
- Algolia search below for non-friends
- Bundled "Also send Friend Request" checkbox for non-friend results (unchecked by default)
- Pending friend requests filtered from Algolia results
- Added usePendingFriendshipsQuery hook to friends service
- Extended AddTripPartyMember.test.tsx with 6 new test cases

Files: AddTripPartyMember.tsx, AddTripPartyMember.test.tsx, friends.ts

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>