### PR TITLE
feat: add Chat Notifications global opt-out toggle in Settings (#68)

### DIFF
--- a/app/components/ChatNotificationsToggle.test.tsx
+++ b/app/components/ChatNotificationsToggle.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { toast } from 'sonner'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../lib/useIsAnonymous', () => ({
+  useIsAnonymous: vi.fn(),
+}))
+
+const mockUpdateUserAsync = vi.fn()
+
+vi.mock('../contexts/auth/useAuth', () => ({
+  useAuth: vi.fn(() => ({
+    user: { uid: 'u1', username: 'testuser', email: 'test@test.com', preferences: {} },
+  })),
+}))
+
+vi.mock('../services/users', () => ({
+  useUpdateUser: vi.fn(() => ({
+    mutateAsync: mockUpdateUserAsync,
+  })),
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn() },
+}))
+
+import { useAuth } from '../contexts/auth/useAuth'
+import { useIsAnonymous } from '../lib/useIsAnonymous'
+import { ChatNotificationsToggle } from './ChatNotificationsToggle'
+
+function renderComponent() {
+  return render(
+    <MemoryRouter>
+      <ChatNotificationsToggle />
+    </MemoryRouter>
+  )
+}
+
+describe('ChatNotificationsToggle', () => {
+  describe('anonymous users', () => {
+    it('does not render for anonymous users', () => {
+      vi.mocked(useIsAnonymous).mockReturnValue(true)
+      const { container } = renderComponent()
+      expect(container.innerHTML).toBe('')
+    })
+  })
+
+  describe('registered users', () => {
+    beforeEach(() => {
+      vi.mocked(useIsAnonymous).mockReturnValue(false)
+      mockUpdateUserAsync.mockReset()
+    })
+
+    it('renders the switch', () => {
+      renderComponent()
+      expect(screen.getByRole('switch')).toBeInTheDocument()
+    })
+
+    it('defaults to on (opted in) when chatNotificationsEnabled is absent', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: { uid: 'u1', username: 'testuser', email: 'test@test.com', preferences: {} },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('defaults to on when preferences is undefined', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: { uid: 'u1', username: 'testuser', email: 'test@test.com' },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('shows off state when chatNotificationsEnabled is false', () => {
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { chatNotificationsEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-checked', 'false')
+    })
+
+    it('writes chatNotificationsEnabled = false when toggling off', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { chatNotificationsEnabled: true },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(mockUpdateUserAsync).toHaveBeenCalledWith({
+        data: { preferences: { chatNotificationsEnabled: false } },
+      })
+    })
+
+    it('writes chatNotificationsEnabled = true when toggling on', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { chatNotificationsEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(mockUpdateUserAsync).toHaveBeenCalledWith({
+        data: { preferences: { chatNotificationsEnabled: true } },
+      })
+    })
+
+    it('shows success toast when toggling off', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { chatNotificationsEnabled: true },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'Chat notifications disabled'
+      )
+    })
+
+    it('shows success toast when toggling on', async () => {
+      const user = userEvent.setup()
+      vi.mocked(useAuth).mockReturnValue({
+        user: {
+          uid: 'u1',
+          username: 'testuser',
+          email: 'test@test.com',
+          preferences: { chatNotificationsEnabled: false },
+        },
+        setUser: vi.fn(),
+      } as any)
+      renderComponent()
+      await user.click(screen.getByRole('switch'))
+      expect(toast.success).toHaveBeenCalledWith(
+        'Chat notifications enabled'
+      )
+    })
+  })
+})

--- a/app/components/ChatNotificationsToggle.tsx
+++ b/app/components/ChatNotificationsToggle.tsx
@@ -1,0 +1,30 @@
+import { toast } from 'sonner'
+
+import { Switch } from '~/components/ui/switch'
+import { useAuth } from '~/contexts/auth/useAuth'
+import { useIsAnonymous } from '~/lib/useIsAnonymous'
+import { useUpdateUser } from '~/services/users'
+
+export function ChatNotificationsToggle() {
+  const isAnonymous = useIsAnonymous()
+  const { user } = useAuth()
+  const { mutateAsync: updateUserAsync } = useUpdateUser(user?.uid ?? '')
+
+  if (isAnonymous) {
+    return null
+  }
+
+  const enabled = user?.preferences?.chatNotificationsEnabled !== false
+
+  const handleToggle = () => {
+    const newValue = !enabled
+    updateUserAsync({
+      data: { preferences: { chatNotificationsEnabled: newValue } },
+    })
+    toast.success(
+      newValue ? 'Chat notifications enabled' : 'Chat notifications disabled'
+    )
+  }
+
+  return <Switch checked={enabled} onCheckedChange={handleToggle} />
+}

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,3 +1,4 @@
+import { ChatNotificationsToggle } from '~/components/ChatNotificationsToggle'
 import { EmergencyContacts } from '~/components/EmergencyContacts'
 import { FriendRequestEmailToggle } from '~/components/FriendRequestEmailToggle'
 import PageContent from '~/components/PageContent'
@@ -69,6 +70,18 @@ export default function Settings() {
               description="Receive an email when someone sends you a friend request."
             >
               <FriendRequestEmailToggle />
+            </PreferenceRow>
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="mb-2 text-lg font-bold">Notifications</h2>
+          <div className="divide-border divide-y">
+            <PreferenceRow
+              label="Chat Notifications"
+              description="Receive push notifications when a trip member sends a chat message."
+            >
+              <ChatNotificationsToggle />
             </PreferenceRow>
           </div>
         </section>

--- a/app/types/User.ts
+++ b/app/types/User.ts
@@ -29,6 +29,7 @@ export type User = {
     hasDismissedFernwoodAd?: Timestamp
     safetyItineraryEnabled?: boolean
     friendRequestEmailEnabled?: boolean
+    chatNotificationsEnabled?: boolean
     temperatureUnit?: 'celsius' | 'fahrenheit'
     weightUnit?: WeightUnitPreferenceType
   }


### PR DESCRIPTION
Child of PRD #58 — Chat Message Notifications.

Key decisions:
- chatNotificationsEnabled defaults to true (enabled) when absent, matching the pattern used by safetyItineraryEnabled and friendRequestEmailEnabled
- Toggle placed in a new "Notifications" section on Settings page
- Cloud Function (#67) will check preferences.chatNotificationsEnabled !== false before including a user in notification sends

Files changed:
- app/types/User.ts — added chatNotificationsEnabled?: boolean to preferences
- app/components/ChatNotificationsToggle.tsx — new toggle component
- app/components/ChatNotificationsToggle.test.tsx — 9 tests covering anonymous users, default states, toggle behavior, mutations, and toasts
- app/routes/settings.tsx — added Notifications section with toggle